### PR TITLE
chore: bumped java chart version to 3.0.0

### DIFF
--- a/charts/ucmc-service/Chart.yaml
+++ b/charts/ucmc-service/Chart.yaml
@@ -1,7 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 description: A Helm chart for ucmc-service App
 name: ucmc-service
 home: https://github.com/hmcts/ucmc-service
-version: 0.0.3
+version: 0.1.0
 maintainers:
   - name: HMCTS Unspecified CMC team

--- a/charts/ucmc-service/requirements.yaml
+++ b/charts/ucmc-service/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
     version: 3.0.0
     repository: '@hmctspublic'
   - name: ccd
-    version: 4.2.4
+    version: 4.3.3
     repository: '@hmctspublic'
     tags:
       - ucmc-ccd-stack

--- a/charts/ucmc-service/requirements.yaml
+++ b/charts/ucmc-service/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: java
-    version: ~2.16.1
+    version: 3.0.0
     repository: '@hmctspublic'
   - name: ccd
     version: 4.2.4

--- a/charts/ucmc-service/values.preview.template.yaml
+++ b/charts/ucmc-service/values.preview.template.yaml
@@ -69,6 +69,7 @@ ccd:
         DATA_STORE_DB_HOST: ${SERVICE_NAME}-postgresql
         DATA_STORE_IDAM_KEY: ${CCD_DATA_STORE_S2S_SECRET}
         DATA_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_ps,bulk_scan_orchestrator,ccpay_bubble,ctsc_work_allocation,em_ccd_orchestrator,xui_webapp,ucmc-service
+        OIDC_ISSUER: https://forgerock-am.service.core-compute-idam-{{ .Values.global.environment }}.internal:8443/openam/oauth2/hmcts
       keyVaults:
       ingressHost: ccd-data-store-api-${SERVICE_FQDN}
   ccd-definition-store-api:

--- a/e2e/tests/smoke_test.js
+++ b/e2e/tests/smoke_test.js
@@ -4,8 +4,8 @@ const baseUrl = process.env.URL || 'http://localhost:3333';
 
 Feature('Smoke tests @smoke-tests');
 
-Scenario('Sign in as solicitor user', (I, loginPage) => {
+Scenario('Sign in as solicitor user', async (I, loginPage) => {
   I.amOnPage(baseUrl);
   loginPage.signIn(config.solicitorUser);
-  I.see('Case List');
+  await I.see('Case List');
 });


### PR DESCRIPTION
### Change description ###

- bumped java and ccd charts versions
- added OIDC_ISSUER env variable to ccd-data-store-api on preview chart

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
