### PR TITLE
refactor: response pack link to open in new tab(CMC-422)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/ucmc/handler/CreateClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/ucmc/handler/CreateClaimCallbackHandler.java
@@ -80,8 +80,8 @@ public class CreateClaimCallbackHandler extends CallbackHandler {
         String body = format(
             "<br />Follow these steps to serve a claim:"
                 + "\n* [Download the sealed claim form](%s) (PDF, 123KB)"
-                + "\n* Send the form, particulars of claim and [a response pack](%s target=\"_blank\") (PDF, 266 KB) "
-                + "to the defendant by %s"
+                + "\n* Send the form, particulars of claim and "
+                + "<a href=\"%s\" target=\"_blank\">a response pack</a> (PDF, 266 KB) to the defendant by %s"
                 + "\n* Confirm service online within 21 days of sending the form, particulars and response pack, before"
                 + " 4pm if you're doing this on the due day", documentLink, responsePackLink, formattedServiceDeadline);
 

--- a/src/main/java/uk/gov/hmcts/reform/ucmc/handler/CreateClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/ucmc/handler/CreateClaimCallbackHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.ucmc.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackResponse;
@@ -29,9 +30,14 @@ public class CreateClaimCallbackHandler extends CallbackHandler {
     private static final List<CaseEvent> EVENTS = Collections.singletonList(CREATE_CASE);
 
     private final ObjectMapper mapper;
+    private final String responsePackLink;
 
-    public CreateClaimCallbackHandler(ObjectMapper mapper) {
+    public CreateClaimCallbackHandler(
+        ObjectMapper mapper,
+        @Value("${unspecified.response-pack-url}") String responsePackLink
+    ) {
         this.mapper = mapper;
+        this.responsePackLink = responsePackLink;
     }
 
     @Override
@@ -67,7 +73,6 @@ public class CreateClaimCallbackHandler extends CallbackHandler {
 
     private SubmittedCallbackResponse buildConfirmation(CallbackParams callbackParams) {
         String documentLink = "https://www.google.com";
-        String responsePackLink = "https://formfinder.hmctsformfinder.justice.gov.uk/n9-eng.pdf";
         LocalDateTime serviceDeadline = LocalDate.now().plusDays(112).atTime(23, 59);
         String formattedServiceDeadline = formatLocalDateTime(serviceDeadline, DATE_TIME_AT);
         String claimNumber = "TBC";
@@ -75,7 +80,7 @@ public class CreateClaimCallbackHandler extends CallbackHandler {
         String body = format(
             "<br />Follow these steps to serve a claim:"
                 + "\n* [Download the sealed claim form](%s) (PDF, 123KB)"
-                + "\n* Send the form, particulars of claim and [a response pack](%s) (PDF, 266 KB) "
+                + "\n* Send the form, particulars of claim and [a response pack](%s target=\"_blank\") (PDF, 266 KB) "
                 + "to the defendant by %s"
                 + "\n* Confirm service online within 21 days of sending the form, particulars and response pack, before"
                 + " 4pm if you're doing this on the due day", documentLink, responsePackLink, formattedServiceDeadline);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,3 +43,6 @@ idam:
     url: "http://localhost:5000"
   s2s-auth:
     microservice: ucmc-service
+
+unspecified:
+  response-pack-url: https://formfinder.hmctsformfinder.justice.gov.uk/n9-eng.pdf

--- a/src/test/java/uk/gov/hmcts/reform/ucmc/handler/CreateClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ucmc/handler/CreateClaimCallbackHandlerTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.ucmc.handler;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
@@ -25,6 +26,8 @@ class CreateClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
 
     @Autowired
     private CreateClaimCallbackHandler handler;
+    @Value("${unspecified.response-pack-url}")
+    private String responsePackLink;
 
     @Test
     void shouldReturnExpectedErrorInMidEventWhenValuesAreInvalid() {
@@ -67,14 +70,13 @@ class CreateClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
         SubmittedCallbackResponse response = (SubmittedCallbackResponse) handler.handle(params);
 
         String documentLink = "https://www.google.com";
-        String responsePackLink = "https://formfinder.hmctsformfinder.justice.gov.uk/n9-eng.pdf";
         LocalDateTime serviceDeadline = LocalDate.now().plusDays(112).atTime(23, 59);
         String formattedServiceDeadline = formatLocalDateTime(serviceDeadline, DATE_TIME_AT);
 
         String body = format(
             "<br />Follow these steps to serve a claim:"
                 + "\n* [Download the sealed claim form](%s) (PDF, 123KB)"
-                + "\n* Send the form, particulars of claim and [a response pack](%s) (PDF, 266 KB) "
+                + "\n* Send the form, particulars of claim and [a response pack](%s target=\"_blank\") (PDF, 266 KB) "
                 + "to the defendant by %s"
                 + "\n* Confirm service online within 21 days of sending the form, particulars and response pack, before"
                 + " 4pm if you're doing this on the due day", documentLink, responsePackLink, formattedServiceDeadline);

--- a/src/test/java/uk/gov/hmcts/reform/ucmc/handler/CreateClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ucmc/handler/CreateClaimCallbackHandlerTest.java
@@ -76,8 +76,8 @@ class CreateClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
         String body = format(
             "<br />Follow these steps to serve a claim:"
                 + "\n* [Download the sealed claim form](%s) (PDF, 123KB)"
-                + "\n* Send the form, particulars of claim and [a response pack](%s target=\"_blank\") (PDF, 266 KB) "
-                + "to the defendant by %s"
+                + "\n* Send the form, particulars of claim and "
+                + "<a href=\"%s\" target=\"_blank\">a response pack</a> (PDF, 266 KB) to the defendant by %s"
                 + "\n* Confirm service online within 21 days of sending the form, particulars and response pack, before"
                 + " 4pm if you're doing this on the due day", documentLink, responsePackLink, formattedServiceDeadline);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[CMC-422](https://tools.hmcts.net/jira/browse/CMC-422)

### Change description ###
This PR contains the change to open the response pack link in new tab on confirmation screen. Also we are making the link configurable in application yaml.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
