### PR TITLE
fix: generic base OIDC issuer with specific aat and preview settings

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -16,7 +16,7 @@ static Map<String, Object> secret(String secretName, String envVariable) {
   ]
 }
 
-def otherSecrets = [
+def secrets = [
   's2s-${env}': [
     secret('microservicekey-ccd-gw', 'CCD_API_GATEWAY_S2S_SECRET'),
     secret('microservicekey-ccd-data', 'CCD_DATA_STORE_S2S_SECRET'),
@@ -59,13 +59,13 @@ withPipeline(type, product, component) {
   enableSlackNotifications('#unspec_notification')
 
   onPR {
-    loadVaultSecrets(otherSecrets)
+    loadVaultSecrets(secrets)
   }
   onMaster {
-    loadVaultSecrets(otherSecrets)
+    loadVaultSecrets(secrets)
   }
   onDemo {
-    loadVaultSecrets(serviceSecrets + otherSecrets)
+    loadVaultSecrets(secrets)
   }
 
   after('checkout') {
@@ -114,10 +114,6 @@ withPipeline(type, product, component) {
 
   after('smoketest:aat') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'output/**/*'
-  }
-
-  before('functionalTest:aat') {
-    env.SKIP_FUNCTIONAL_TESTS = 'true'
   }
 
   before('buildinfra:demo') {

--- a/charts/unspec-service/Chart.yaml
+++ b/charts/unspec-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for unspec-service App
 name: unspec-service
 home: https://github.com/hmcts/unspec-service
-version: 1.2.2
+version: 1.2.3
 maintainers:
   - name: HMCTS Unspecified team
 

--- a/charts/unspec-service/values.aat.template.yaml
+++ b/charts/unspec-service/values.aat.template.yaml
@@ -1,3 +1,5 @@
 java:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
+  environment:
+    OIDC_ISSUER: https://forgerock-am.service.core-compute-idam-aat2.internal:8443/openam/oauth2/realms/root/realms/hmcts

--- a/charts/unspec-service/values.preview.template.yaml
+++ b/charts/unspec-service/values.preview.template.yaml
@@ -6,6 +6,7 @@ java:
   ingressHost: ${SERVICE_FQDN}
   environment:
     CORE_CASE_DATA_API_URL: http://${SERVICE_NAME}-ccd-data-store-api
+    OIDC_ISSUER: https://forgerock-am.service.core-compute-idam-aat2.internal:8443/openam/oauth2/realms/root/realms/hmcts
 
 idam-pr:
   releaseNameOverride: ${SERVICE_NAME}-xui-idam-pr

--- a/charts/unspec-service/values.yaml
+++ b/charts/unspec-service/values.yaml
@@ -25,7 +25,7 @@ java:
     SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/o/jwks
     AUTH_IDAM_CLIENT_BASEURL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
     AUTH_PROVIDER_SERVICE_CLIENT_BASEURL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
-    OIDC_ISSUER: https://forgerock-am.service.core-compute-idam-aat2.internal:8443/openam/oauth2/realms/root/realms/hmcts
+    OIDC_ISSUER: https://forgerock-am.service.core-compute-idam-{{ .Values.global.environment }}.internal:8443/openam/oauth2/realms/root/realms/hmcts
     FEES_API_URL: http://fees-register-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     PAYMENTS_API_URL: http://payment-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
   keyVaults:


### PR DESCRIPTION
### Change description ###

- set generic value for OIDC issuer in base chart (so correct value is picked up by demo and other envs in the future)
- set aat2 issuer for preview and aat
- toggled on functional tests on aat

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
