### PR TITLE
fix: pointed ccd definition to staging service instead of aat

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -108,8 +108,8 @@ withPipeline(type, product, component) {
 
   before('smoketest:aat') {
     env.URL = "https://manage-case.aat.platform.hmcts.net"
-//    archiveCoreCaseDataDefinitions('aat')
-//    uploadCoreCaseDataDefinitions('aat')
+    archiveCoreCaseDataDefinitions('aat')
+    uploadCoreCaseDataDefinitions('aat')
   }
 
   after('smoketest:aat') {

--- a/bin/build-release-ccd-definition.sh
+++ b/bin/build-release-ccd-definition.sh
@@ -22,6 +22,7 @@ release_definition_output_file=${build_dir}/ccd-unspec-${environment}.xlsx
 
 mkdir -p ${build_dir}
 
+$(${root_dir}/bin/variables/load-${environment}-environment-variables.sh)
+
 # build the ccd definition file
-export CCD_DEF_CASE_SERVICE_BASE_URL=http://unspec-service-${environment}.service.core-compute-${environment}.internal
 ${root_dir}/civil-unspecified-docker/bin/utils/process-definition.sh ${config_dir} ${release_definition_output_file} "${excludedFilenamePatterns}"

--- a/bin/variables/load-aat-environment-variables.sh
+++ b/bin/variables/load-aat-environment-variables.sh
@@ -11,4 +11,4 @@ echo "export CCD_IDAM_REDIRECT_URL=https://ccd-case-management-web-aat.service.c
 echo "export CCD_DEFINITION_STORE_API_BASE_URL=http://ccd-definition-store-api-aat.service.core-compute-aat.internal"
 
 # definition placeholders
-echo "export CCD_DEF_CASE_SERVICE_BASE_URL=http://unspec-service-aat.service.core-compute-aat.internal"
+echo "export CCD_DEF_CASE_SERVICE_BASE_URL=http://unspec-service-staging.service.core-compute-aat.internal"


### PR DESCRIPTION
### Change description ###

Updated AAT definition to make calls to staging service, so our master pipeline won't fail when introducing breaking changes to our backend code.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
