### PR TITLE
fix: added missing await for case header in failing e2e test

### DIFF
--- a/e2e/steps_file.js
+++ b/e2e/steps_file.js
@@ -148,6 +148,7 @@ module.exports = function () {
       await this.retryUntilExists(() => this.click('Submit response'), 'ccd-markdown');
       this.see('You\'ve submitted your response');
       this.click('Close and Return to case details');
+      this.waitForElement(CASE_HEADER);
     },
 
     async clickContinue() {


### PR DESCRIPTION
### Change description ###

Added missing await for case header in failing e2e test

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
