### PR TITLE
fix: reverted change to SearchSourceBuilder (CMC-NA)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/unspec/model/search/Query.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/model/search/Query.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.unspec.model.search;
+
+import org.elasticsearch.index.query.QueryBuilder;
+
+import java.util.List;
+import java.util.Objects;
+
+public class Query {
+
+    private final QueryBuilder queryBuilder;
+    private final List<String> dataToReturn;
+    private final int startIndex;
+
+    public Query(QueryBuilder queryBuilder, List<String> dataToReturn, int startIndex) {
+        Objects.requireNonNull(queryBuilder, "QueryBuilder cannot be null in search");
+        if (startIndex < 0) {
+            throw new IllegalArgumentException("Start index cannot be less than 0");
+        }
+        this.queryBuilder = queryBuilder;
+        this.dataToReturn = dataToReturn;
+        this.startIndex = startIndex;
+    }
+
+    @Override
+    public String toString() {
+        return "{"
+            + "\"query\": " + queryBuilder.toString() + ", "
+            + "\"_source\": " + dataToReturn + ", "
+            + "\"from\": " + startIndex
+            + "}";
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/unspec/service/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/service/CoreCaseDataService.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.unspec.service;
 
 import lombok.RequiredArgsConstructor;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
@@ -12,6 +11,7 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.unspec.callback.CaseEvent;
 import uk.gov.hmcts.reform.unspec.config.SystemUpdateUserConfiguration;
+import uk.gov.hmcts.reform.unspec.model.search.Query;
 
 import static uk.gov.hmcts.reform.unspec.CaseDefinitionConstants.CASE_TYPE;
 import static uk.gov.hmcts.reform.unspec.CaseDefinitionConstants.JURISDICTION;
@@ -51,7 +51,7 @@ public class CoreCaseDataService {
         );
     }
 
-    public SearchResult searchCases(SearchSourceBuilder query) {
+    public SearchResult searchCases(Query query) {
         String userToken = idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
 
         return coreCaseDataApi.searchCases(userToken, authTokenGenerator.generate(), CASE_TYPE, query.toString());

--- a/src/main/java/uk/gov/hmcts/reform/unspec/service/search/CaseStayedSearchService.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/service/search/CaseStayedSearchService.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.unspec.service.search;
 
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.unspec.model.search.Query;
 import uk.gov.hmcts.reform.unspec.service.CoreCaseDataService;
+
+import java.util.List;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
@@ -15,12 +17,13 @@ public class CaseStayedSearchService extends ElasticSearchService {
         super(coreCaseDataService);
     }
 
-    public SearchSourceBuilder query(int startIndex) {
-        return new SearchSourceBuilder()
-            .query(boolQuery()
+    public Query query(int startIndex) {
+        return new Query(
+            boolQuery()
                 .must(rangeQuery("data.confirmationOfServiceDeadline").lt("now"))
-                .must(matchQuery("state", "CREATED")))
-            .fetchSource("reference", null)
-            .from(startIndex);
+                .must(matchQuery("state", "CREATED")),
+            List.of("reference"),
+            startIndex
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/unspec/service/search/ElasticSearchService.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/service/search/ElasticSearchService.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.reform.unspec.service.search;
 
 import lombok.RequiredArgsConstructor;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
+import uk.gov.hmcts.reform.unspec.model.search.Query;
 import uk.gov.hmcts.reform.unspec.service.CoreCaseDataService;
 
 import java.math.BigDecimal;
@@ -33,7 +33,7 @@ public abstract class ElasticSearchService {
         return caseDetails;
     }
 
-    abstract SearchSourceBuilder query(int startIndex);
+    abstract Query query(int startIndex);
 
     private int calculatePages(SearchResult searchResult) {
         return new BigDecimal(searchResult.getTotal()).divide(new BigDecimal(ES_DEFAULT_SEARCH_LIMIT), UP).intValue();

--- a/src/test/java/uk/gov/hmcts/reform/unspec/model/search/QueryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/model/search/QueryTest.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.reform.unspec.model.search;
+
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class QueryTest {
+
+    @Test
+    void shouldThrowException_WhenIndexLessThan0() {
+        assertThrows(IllegalArgumentException.class, () ->
+                         new Query(QueryBuilders.matchQuery("field", "value"), List.of(), -1),
+                     "Start index cannot be less than 0"
+        );
+    }
+
+    @Test
+    void shouldThrowException_WhenQueryIsNull() {
+        assertThrows(NullPointerException.class, () ->
+                         new Query(null, List.of(), 0),
+                     "QueryBuilder cannot be null in search"
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/unspec/service/CoreCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/service/CoreCaseDataServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.unspec.service;
 
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,10 +19,12 @@ import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 import uk.gov.hmcts.reform.unspec.callback.CaseEvent;
 import uk.gov.hmcts.reform.unspec.config.SystemUpdateUserConfiguration;
+import uk.gov.hmcts.reform.unspec.model.search.Query;
 
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -110,9 +111,7 @@ class CoreCaseDataServiceTest {
 
         @Test
         void shouldReturnCases_WhenSearchingCasesAsSystemUpdateUser() {
-            SearchSourceBuilder query = new SearchSourceBuilder()
-                .query(QueryBuilders.matchQuery("field", "value"))
-                .from(0);
+            Query query = new Query(QueryBuilders.matchQuery("field", "value"), emptyList(), 0);
 
             List<CaseDetails> cases = List.of(CaseDetails.builder().id(1L).build());
             SearchResult searchResult = SearchResult.builder().cases(cases).build();


### PR DESCRIPTION

### JIRA link (if applicable) ###

n/a

### Change description ###

CCD endpoint does not work with ElasticSearch java objects.

SearchSourceBuilder creates "_source" field with "includes" and "excludes" fields resulting in a class cast exception in [ccd-data-store]( https://github.com/hmcts/ccd-data-store-api/blob/master/src/main/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/CrossCaseTypeSearchRequest.java#L91). Data store just expects a list.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
