### PR TITLE
chore: bumped owasp dependencycheck plugin version to 6 (CMC-NA)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,7 +276,7 @@ dependencies {
   implementation group: 'org.springframework.security', name: 'spring-security-config'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-client'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-resource-server'
-  implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.0.1'
+  implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '8.20'
   implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
   implementation group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '1.5.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
   id 'org.springframework.boot' version '2.3.4.RELEASE'
-  id 'org.owasp.dependencycheck' version '5.3.2.1'
+  id 'org.owasp.dependencycheck' version '6.0.1'
   id 'com.github.ben-manes.versions' version '0.33.0'
   id 'org.sonarqube' version '3.0'
   id 'au.com.dius.pact' version '4.1.7'
@@ -276,7 +276,7 @@ dependencies {
   implementation group: 'org.springframework.security', name: 'spring-security-config'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-client'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-resource-server'
-  implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '8.20'
+  implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.0.1'
   implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
   implementation group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '1.5.5'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -12,5 +12,12 @@
     <notes><![CDATA[Awaiting version bump from jackson-module-kotlin to take 1.3.7 -> 1.4]]></notes>
     <cve>CVE-2020-15824</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+      CVE is a json vulnerability for Node projects. False positive reported at https://github.com/jeremylong/DependencyCheck/issues/2794
+  ]]></notes>
+    <cve>CVE-2020-10663</cve>
+    <cve>CVE-2020-7712</cve>
+  </suppress>
 
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -19,5 +19,9 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
   </suppress>
-
+  <suppress>
+    <notes><![CDATA[Awaiting openid dependencies version bump in nimbus-jose-jwt]]></notes>
+    <cve>CVE-2007-1651</cve>
+    <cve>CVE-2007-1652</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

Bumped owasp dependencycheck plugin version to 6 (CMC-NA)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
