### PR TITLE
fix: renamed claim value field and added to pounds method (CMC-899)

### DIFF
--- a/ccd-definition/ComplexTypes/ClaimValue.json
+++ b/ccd-definition/ComplexTypes/ClaimValue.json
@@ -8,7 +8,7 @@
   },
   {
     "ID": "ClaimValue",
-    "ListElementCode": "statementOfValue",
+    "ListElementCode": "statementOfValueInPennies",
     "FieldType": "MoneyGBP",
     "ElementLabel": "Statement of value",
     "SecurityClassification": "Public"

--- a/e2e/fixtures/createClaim.js
+++ b/e2e/fixtures/createClaim.js
@@ -73,7 +73,7 @@ module.exports = {
     },
     claimValue: {
       claimValue: {
-        statementOfValue: '500'
+        statementOfValueInPennies: '500'
       }
     },
     statementOfTruth: {

--- a/e2e/pages/createClaim/claimValue.page.js
+++ b/e2e/pages/createClaim/claimValue.page.js
@@ -5,7 +5,7 @@ const statementOfTruth = require('../../fragments/statementOfTruth');
 module.exports = {
 
   fields: {
-    statementOfValue: '#claimValue_statementOfValue',
+    statementOfValue: '#claimValue_statementOfValueInPennies',
   },
 
   async enterClaimValue() {

--- a/src/main/java/uk/gov/hmcts/reform/unspec/enums/AllocatedTrack.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/enums/AllocatedTrack.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.unspec.enums;
 
-import uk.gov.hmcts.reform.unspec.model.ClaimValue;
-
 import java.math.BigDecimal;
 
 public enum AllocatedTrack {
@@ -9,18 +7,18 @@ public enum AllocatedTrack {
     FAST_CLAIM,
     MULTI_CLAIM;
 
-    public static AllocatedTrack getAllocatedTrack(ClaimValue claimValue, ClaimType claimType) {
+    public static AllocatedTrack getAllocatedTrack(BigDecimal statementOfValueInPounds, ClaimType claimType) {
         if (claimType.isLowerFeeType()) {
-            if (isValueSmallerThan(claimValue.getStatementOfValue(), 1000)) {
+            if (isValueSmallerThan(statementOfValueInPounds, 1000)) {
                 return SMALL_CLAIM;
-            } else if (isValueWithinRange(claimValue.getStatementOfValue(), 1000, 25000)) {
+            } else if (isValueWithinRange(statementOfValueInPounds, 1000, 25000)) {
                 return FAST_CLAIM;
             }
         }
 
-        if (isValueSmallerThan(claimValue.getStatementOfValue(), 10000)) {
+        if (isValueSmallerThan(statementOfValueInPounds, 10000)) {
             return SMALL_CLAIM;
-        } else if (isValueWithinRange(claimValue.getStatementOfValue(), 10000, 25000)) {
+        } else if (isValueWithinRange(statementOfValueInPounds, 10000, 25000)) {
             return FAST_CLAIM;
         } else {
             return MULTI_CLAIM;

--- a/src/main/java/uk/gov/hmcts/reform/unspec/handler/callback/CreateClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/handler/callback/CreateClaimCallbackHandler.java
@@ -119,7 +119,7 @@ public class CreateClaimCallbackHandler extends CallbackHandler {
         data.put(CLAIMANT, caseData.getApplicant1());
         data.put("legacyCaseReference", referenceNumber);
         data.put("businessProcess", BusinessProcess.builder().activityId("ClaimIssueHandling").build());
-        data.put("allocatedTrack", getAllocatedTrack(caseData.getClaimValue(), caseData.getClaimType()));
+        data.put("allocatedTrack", getAllocatedTrack(caseData.getClaimValue().toPounds(), caseData.getClaimType()));
 
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(data)

--- a/src/main/java/uk/gov/hmcts/reform/unspec/model/ClaimValue.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/model/ClaimValue.java
@@ -12,16 +12,18 @@ import java.math.BigDecimal;
 @Builder
 public class ClaimValue {
 
-    private final BigDecimal statementOfValue;
+    private final BigDecimal statementOfValueInPennies;
 
     @JsonCreator
-    public ClaimValue(@JsonProperty("statementOfValue") BigDecimal statementOfValue) {
-        this.statementOfValue = statementOfValue;
+    public ClaimValue(@JsonProperty("statementOfValueInPennies") BigDecimal statementOfValueInPennies) {
+        this.statementOfValueInPennies = statementOfValueInPennies;
+    }
+
+    public BigDecimal toPounds() {
+        return MonetaryConversions.penniesToPounds(this.statementOfValueInPennies);
     }
 
     public String formData() {
-        BigDecimal statementOfValue = MonetaryConversions.penniesToPounds(this.statementOfValue);
-
-        return "up to £" + statementOfValue;
+        return "up to £" + this.toPounds();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/unspec/service/FeesService.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/service/FeesService.java
@@ -10,42 +10,36 @@ import uk.gov.hmcts.reform.unspec.model.ClaimValue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.math.RoundingMode;
 
 @Service
 @RequiredArgsConstructor
 public class FeesService {
 
     private static final BigDecimal PENCE_PER_POUND = BigDecimal.valueOf(100);
-    private static final int ROUNDING_SCALE = 2;
 
     private final FeesClient feesClient;
     private final FeesConfiguration feesConfiguration;
 
     public BigInteger getFeeAmountByClaimValue(ClaimValue claimValue) {
-        FeeLookupResponseDto feeLookupResponseDto = lookupFee(claimValue.getStatementOfValue());
+        FeeLookupResponseDto feeLookupResponseDto = lookupFee(claimValue);
 
         return getFeeAmountInPence(feeLookupResponseDto);
     }
 
     public FeeDto getFeeDataByClaimValue(ClaimValue claimValue) {
-        FeeLookupResponseDto feeLookupResponseDto = lookupFee(claimValue.getStatementOfValue());
+        FeeLookupResponseDto feeLookupResponseDto = lookupFee(claimValue);
 
         return buildFeeDto(feeLookupResponseDto);
     }
 
-    private FeeLookupResponseDto lookupFee(BigDecimal claimStatementOfValue) {
-        var claimStatementOfValuePounds = convertToPounds(claimStatementOfValue);
+    private FeeLookupResponseDto lookupFee(ClaimValue claimValue) {
+        var claimStatementOfValuePounds = claimValue.toPounds();
 
         return feesClient.lookupFee(
             feesConfiguration.getChannel(),
             feesConfiguration.getEvent(),
             claimStatementOfValuePounds
         );
-    }
-
-    private BigDecimal convertToPounds(BigDecimal value) {
-        return value.divide(PENCE_PER_POUND, ROUNDING_SCALE, RoundingMode.UNNECESSARY);
     }
 
     private BigInteger getFeeAmountInPence(FeeLookupResponseDto feeLookupResponseDto) {

--- a/src/test/java/uk/gov/hmcts/reform/unspec/enums/AllocatedTrackTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/enums/AllocatedTrackTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.unspec.enums;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import uk.gov.hmcts.reform.unspec.model.ClaimValue;
 
 import java.math.BigDecimal;
 
@@ -23,9 +22,7 @@ class AllocatedTrackTest {
             value = ClaimType.class,
             names = {"PERSONAL_INJURY", "CLINICAL_NEGLIGENCE"})
         void shouldAllocatePersonalInjuryClaimTypesBelow1000ToSmallClaim(ClaimType claimType) {
-            ClaimValue claimValue = claimValueWithStatementOfValueOf(BigDecimal.valueOf(999));
-
-            AllocatedTrack track = getAllocatedTrack(claimValue, claimType);
+            AllocatedTrack track = getAllocatedTrack(BigDecimal.valueOf(999), claimType);
 
             assertThat(track).isEqualTo(SMALL_CLAIM);
         }
@@ -35,9 +32,7 @@ class AllocatedTrackTest {
             value = ClaimType.class,
             names = {"PERSONAL_INJURY", "CLINICAL_NEGLIGENCE"})
         void shouldAllocatePersonalInjuryClaimTypesOf1000ToFastClaim(ClaimType claimType) {
-            ClaimValue claimValue = claimValueWithStatementOfValueOf(BigDecimal.valueOf(1000));
-
-            assertThat(getAllocatedTrack(claimValue, claimType)).isEqualTo(FAST_CLAIM);
+            assertThat(getAllocatedTrack(BigDecimal.valueOf(1000), claimType)).isEqualTo(FAST_CLAIM);
         }
 
         @ParameterizedTest(name = "{0} has fast claim track when claim value is more than 1000 but less than 25001")
@@ -45,9 +40,7 @@ class AllocatedTrackTest {
             value = ClaimType.class,
             names = {"PERSONAL_INJURY", "CLINICAL_NEGLIGENCE"})
         void shouldAllocatePersonalInjuryClaimTypesAbove1000AndBelow25000ToFastClaim(ClaimType claimType) {
-            ClaimValue claimValue = claimValueWithStatementOfValueOf(BigDecimal.valueOf(25000));
-
-            assertThat(getAllocatedTrack(claimValue, claimType)).isEqualTo(FAST_CLAIM);
+            assertThat(getAllocatedTrack(BigDecimal.valueOf(25000), claimType)).isEqualTo(FAST_CLAIM);
         }
 
         @ParameterizedTest(name = "{0} has multi claim track when claim value is more than 25000")
@@ -55,9 +48,7 @@ class AllocatedTrackTest {
             value = ClaimType.class,
             names = {"PERSONAL_INJURY", "CLINICAL_NEGLIGENCE"})
         void shouldAllocatePersonalInjuryClaimTypesAbove25000ToMultiClaim(ClaimType claimType) {
-            ClaimValue claimValue = claimValueWithStatementOfValueOf(BigDecimal.valueOf(25001));
-
-            assertThat(getAllocatedTrack(claimValue, claimType)).isEqualTo(MULTI_CLAIM);
+            assertThat(getAllocatedTrack(BigDecimal.valueOf(25001), claimType)).isEqualTo(MULTI_CLAIM);
         }
     }
 
@@ -69,9 +60,7 @@ class AllocatedTrackTest {
             value = ClaimType.class,
             names = {"BREACH_OF_CONTRACT", "CONSUMER_CREDIT", "OTHER"})
         void shouldAllocateOtherClaimTypesBelow1000ToSmallClaim(ClaimType claimType) {
-            ClaimValue claimValue = claimValueWithStatementOfValueOf(BigDecimal.valueOf(9999));
-
-            assertThat(getAllocatedTrack(claimValue, claimType)).isEqualTo(SMALL_CLAIM);
+            assertThat(getAllocatedTrack(BigDecimal.valueOf(9999), claimType)).isEqualTo(SMALL_CLAIM);
         }
 
         @ParameterizedTest(name = "{0} has fast claim track when claim value is 10000")
@@ -79,9 +68,7 @@ class AllocatedTrackTest {
             value = ClaimType.class,
             names = {"BREACH_OF_CONTRACT", "CONSUMER_CREDIT", "OTHER"})
         void shouldAllocateOtherClaimTypesOf10000ToFastClaim(ClaimType claimType) {
-            ClaimValue claimValue = claimValueWithStatementOfValueOf(BigDecimal.valueOf(10000));
-
-            assertThat(getAllocatedTrack(claimValue, claimType)).isEqualTo(FAST_CLAIM);
+            assertThat(getAllocatedTrack(BigDecimal.valueOf(10000), claimType)).isEqualTo(FAST_CLAIM);
         }
 
         @ParameterizedTest(name = "{0} has fast claim track if claim value is more than 10000 but less/equal to 25000")
@@ -89,9 +76,7 @@ class AllocatedTrackTest {
             value = ClaimType.class,
             names = {"BREACH_OF_CONTRACT", "CONSUMER_CREDIT", "OTHER"})
         void shouldAllocateOtherClaimTypesAbove10000AndBelow25000ToFastClaim(ClaimType claimType) {
-            ClaimValue claimValue = claimValueWithStatementOfValueOf(BigDecimal.valueOf(25000));
-
-            assertThat(getAllocatedTrack(claimValue, claimType)).isEqualTo(FAST_CLAIM);
+            assertThat(getAllocatedTrack(BigDecimal.valueOf(25000), claimType)).isEqualTo(FAST_CLAIM);
         }
 
         @ParameterizedTest(name = "{0} has multi claim track when claim value is more than 25000")
@@ -99,13 +84,7 @@ class AllocatedTrackTest {
             value = ClaimType.class,
             names = {"BREACH_OF_CONTRACT", "CONSUMER_CREDIT", "OTHER"})
         void shouldAllocateOtherClaimTypesAbove25000ToMultiClaim(ClaimType claimType) {
-            ClaimValue claimValue = claimValueWithStatementOfValueOf(BigDecimal.valueOf(25001));
-
-            assertThat(getAllocatedTrack(claimValue, claimType)).isEqualTo(MULTI_CLAIM);
+            assertThat(getAllocatedTrack(BigDecimal.valueOf(25001), claimType)).isEqualTo(MULTI_CLAIM);
         }
-    }
-
-    private ClaimValue claimValueWithStatementOfValueOf(BigDecimal statementOfValue) {
-        return ClaimValue.builder().statementOfValue(statementOfValue).build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/unspec/sampledata/CaseDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/sampledata/CaseDataBuilder.java
@@ -98,7 +98,7 @@ public class CaseDataBuilder {
             .applicantPreferredCourt("The court location")
             .build();
         claimValue = ClaimValue.builder()
-            .statementOfValue(BigDecimal.valueOf(100000))
+            .statementOfValueInPennies(BigDecimal.valueOf(10000000))
             .build();
         claimType = ClaimType.PERSONAL_INJURY;
         personalInjuryType = ROAD_ACCIDENT;

--- a/src/test/java/uk/gov/hmcts/reform/unspec/service/FeesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/service/FeesServiceTest.java
@@ -53,7 +53,7 @@ class FeesServiceTest {
     @Test
     void shouldReturnFeeAmount_whenValidClaimValue() {
         var claimValue = ClaimValue.builder()
-            .statementOfValue(BigDecimal.valueOf(5000))
+            .statementOfValueInPennies(BigDecimal.valueOf(5000))
             .build();
 
         BigInteger feeAmount = feesService.getFeeAmountByClaimValue(claimValue);
@@ -65,7 +65,7 @@ class FeesServiceTest {
     @Test
     void shouldReturnFeeData_whenValidClaimValue() {
         var claimValue = ClaimValue.builder()
-            .statementOfValue(BigDecimal.valueOf(5000))
+            .statementOfValueInPennies(BigDecimal.valueOf(5000))
             .build();
 
         FeeDto expectedFeeDto = FeeDto.builder()

--- a/src/test/java/uk/gov/hmcts/reform/unspec/service/PaymentsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/service/PaymentsServiceTest.java
@@ -81,7 +81,7 @@ class PaymentsServiceTest {
         CaseDetails caseDetails = CaseDetails.builder()
             .id(1L)
             .data(Map.of(
-                "claimValue", Map.of("statementOfValue", "500"),
+                "claimValue", Map.of("statementOfValueInPennies", "500"),
                 "pbaNumber", "PBA1234567",
                 "caseReference", "case reference",
                 "customerReference", "customer reference",
@@ -102,7 +102,7 @@ class PaymentsServiceTest {
             .fees(new FeeDto[]{FEE_DATA})
             .build();
         var expectedClaimValue = ClaimValue.builder()
-            .statementOfValue(BigDecimal.valueOf(500))
+            .statementOfValueInPennies(BigDecimal.valueOf(500))
             .build();
 
         PaymentDto paymentResponse = paymentsService.createCreditAccountPayment(caseDetails);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-899

### Change description ###

CCD sends back GBP field as pennies. This was throwing off the allocated track logic.
Renamed CCD field and added to pounds method. 

Refactored logic touched by above fix

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
