### PR TITLE
fix: use case details before for callback handler factory (CMC-NA)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/unspec/service/tasks/handler/CaseEventTaskHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/service/tasks/handler/CaseEventTaskHandler.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.unspec.service.tasks.handler;
 
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.camunda.bpm.client.task.ExternalTask;
 import org.camunda.bpm.client.task.ExternalTaskHandler;
 import org.camunda.bpm.client.task.ExternalTaskService;
@@ -11,8 +13,9 @@ import uk.gov.hmcts.reform.unspec.service.CoreCaseDataService;
 
 import java.util.Map;
 
-@RequiredArgsConstructor
 @Component
+@Slf4j
+@RequiredArgsConstructor
 public class CaseEventTaskHandler implements ExternalTaskHandler {
 
     private final CoreCaseDataService coreCaseDataService;
@@ -23,14 +26,19 @@ public class CaseEventTaskHandler implements ExternalTaskHandler {
         Long ccdId = (Long) allVariables.get("CCD_ID");
         String eventId = (String) allVariables.get("CASE_EVENT");
 
-        coreCaseDataService.triggerEvent(
-            ccdId,
-            CaseEvent.valueOf(eventId),
-            Map.of(
-                "businessProcess",
-                BusinessProcess.builder().activityId(externalTask.getActivityId()).build()
-            )
-        );
+        try {
+            coreCaseDataService.triggerEvent(
+                ccdId,
+                CaseEvent.valueOf(eventId),
+                Map.of(
+                    "businessProcess",
+                    BusinessProcess.builder().activityId(externalTask.getActivityId()).build()
+                )
+            );
+        } catch (FeignException e) {
+            log.error(e.contentUTF8());
+            throw e;
+        }
         externalTaskService.complete(externalTask);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/unspec/callback/CallbackHandlerFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/callback/CallbackHandlerFactoryTest.java
@@ -123,7 +123,7 @@ class CallbackHandlerFactoryTest {
         CallbackRequest callbackRequest = CallbackRequest
             .builder()
             .eventId(CREATE_CLAIM.name())
-            .caseDetails(CaseDetails.builder().data(Map.of("state", "created")).build())
+            .caseDetailsBefore(CaseDetails.builder().data(Map.of("state", "created")).build())
             .build();
 
         CallbackParams params = CallbackParams.builder()
@@ -143,7 +143,7 @@ class CallbackHandlerFactoryTest {
         CallbackRequest callbackRequest = CallbackRequest
             .builder()
             .eventId(NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_ISSUE.name())
-            .caseDetails(CaseDetails.builder().data(Map.of(
+            .caseDetailsBefore(CaseDetails.builder().data(Map.of(
                 "businessProcess",
                 BusinessProcess.builder().activityId("CreateClaimNotifyRespondentSolicitor1").build()
             )).build())
@@ -166,7 +166,7 @@ class CallbackHandlerFactoryTest {
         CallbackRequest callbackRequest = CallbackRequest
             .builder()
             .eventId(NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_ISSUE.name())
-            .caseDetails(CaseDetails.builder().data(Map.of(
+            .caseDetailsBefore(CaseDetails.builder().data(Map.of(
                 "businessProcess",
                 BusinessProcess.builder().activityId("unProcessedTask").build()
             )).build())
@@ -189,7 +189,7 @@ class CallbackHandlerFactoryTest {
         CallbackRequest callbackRequest = CallbackRequest
             .builder()
             .eventId(CREATE_CLAIM.name())
-            .caseDetails(CaseDetails.builder().data(Map.of(
+            .caseDetailsBefore(CaseDetails.builder().data(Map.of(
                 "businessProcess",
                 BusinessProcess.builder().activityId("unProcessedTask").build()
             )).build())

--- a/src/test/java/uk/gov/hmcts/reform/unspec/callback/CallbackHandlerFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/callback/CallbackHandlerFactoryTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.unspec.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.unspec.model.BusinessProcess;
 
 import java.util.Collections;
@@ -29,6 +30,7 @@ import static uk.gov.hmcts.reform.unspec.callback.CaseEvent.NOTIFY_RESPONDENT_SO
 
 @SpringBootTest(classes = {
     CallbackHandlerFactory.class,
+    CaseDetailsConverter.class,
     JacksonAutoConfiguration.class},
     properties = {"spring.main.allow-bean-definition-overriding=true"}
 )
@@ -191,6 +193,25 @@ class CallbackHandlerFactoryTest {
                 "businessProcess",
                 BusinessProcess.builder().activityId("unProcessedTask").build()
             )).build())
+            .build();
+
+        CallbackParams params = CallbackParams.builder()
+            .request(callbackRequest)
+            .type(ABOUT_TO_SUBMIT)
+            .version(V_1)
+            .params(ImmutableMap.of(CallbackParams.Params.BEARER_TOKEN, BEARER_TOKEN))
+            .build();
+
+        CallbackResponse callbackResponse = callbackHandlerFactory.dispatch(params);
+
+        assertEquals(EVENT_HANDLED_RESPONSE, callbackResponse);
+    }
+
+    @Test
+    void shouldProcessEvent_whenEventHasNoCaseDetailsBefore() {
+        CallbackRequest callbackRequest = CallbackRequest
+            .builder()
+            .eventId(CREATE_CLAIM.name())
             .build();
 
         CallbackParams params = CallbackParams.builder()


### PR DESCRIPTION
### Change description ###

- CaseEventTaskHandler is sending case data with business process activity id updated to currently processed task. Therefore CallbackHandlerFactory needs to use caseDetailsBefore, otherwise it will always reject the event
- Added logging errors in CaseEventTaskHandler for more convenient debugging

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
