### PR TITLE
fix: respond extension date validation (CMC-NA)

### DIFF
--- a/ccd-definition/CaseEventToFields/RespondExtension.json
+++ b/ccd-definition/CaseEventToFields/RespondExtension.json
@@ -58,7 +58,8 @@
     "PageColumnNumber": 1,
     "CaseEventFieldLabel": "Your current deadline is",
     "DisplayContextParameter" : "#DATETIMEDISPLAY(dd MMM yyyy HH:mm)",
-    "ShowSummaryChangeOption": "N"
+    "ShowSummaryChangeOption": "N",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/counter"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -71,8 +72,7 @@
     "PageDisplayOrder": 2,
     "PageColumnNumber": 1,
     "PageShowCondition": "respondentSolicitor1claimResponseExtensionAccepted=\"No\"",
-    "ShowSummaryChangeOption": "Y",
-    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/counter"
+    "ShowSummaryChangeOption": "Y"
   },
   {
     "LiveFrom": "01/01/2017",


### PR DESCRIPTION
### Change description ###

Date validation callback was not triggered in respond extension event.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
