### PR TITLE
fix: dispatch business process only on event emitter (CMC-944)

### DIFF
--- a/ccd-definition/CaseEvent.json
+++ b/ccd-definition/CaseEvent.json
@@ -323,6 +323,7 @@
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-start",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-submit",
     "ShowSummary": "N",
     "ShowEventNotes": "N"

--- a/src/main/java/uk/gov/hmcts/reform/unspec/aspect/EventEmitterAspect.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/aspect/EventEmitterAspect.java
@@ -27,7 +27,7 @@ public class EventEmitterAspect {
         if (callbackParams.getType() == SUBMITTED) {
             CaseData caseData = callbackParams.getCaseData();
             if (caseData.getBusinessProcess() != null && caseData.getBusinessProcess().getStatus() == READY) {
-                eventEmitterService.emitBusinessProcessCamundaEvent(caseData);
+                eventEmitterService.emitBusinessProcessCamundaEvent(caseData, false);
             }
         }
         return joinPoint.proceed();

--- a/src/main/java/uk/gov/hmcts/reform/unspec/handler/callback/DispatchBusinessProcessCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/handler/callback/DispatchBusinessProcessCallbackHandler.java
@@ -12,14 +12,17 @@ import uk.gov.hmcts.reform.unspec.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.unspec.model.BusinessProcess;
 import uk.gov.hmcts.reform.unspec.model.CaseData;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.unspec.callback.CallbackType.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.unspec.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.unspec.callback.CaseEvent.DISPATCH_BUSINESS_PROCESS;
 import static uk.gov.hmcts.reform.unspec.enums.BusinessProcessStatus.DISPATCHED;
 import static uk.gov.hmcts.reform.unspec.enums.BusinessProcessStatus.READY;
+import static uk.gov.hmcts.reform.unspec.enums.BusinessProcessStatus.STARTED;
 
 @Service
 @RequiredArgsConstructor
@@ -31,12 +34,28 @@ public class DispatchBusinessProcessCallbackHandler extends CallbackHandler {
 
     @Override
     protected Map<String, Callback> callbacks() {
-        return Map.of(callbackKey(ABOUT_TO_SUBMIT), this::dispatchBusinessProcess);
+        return Map.of(
+            callbackKey(ABOUT_TO_START), this::checkIfBusinessProcessStarted,
+            callbackKey(ABOUT_TO_SUBMIT), this::dispatchBusinessProcess
+        );
     }
 
     @Override
     public List<CaseEvent> handledEvents() {
         return EVENTS;
+    }
+
+    private CallbackResponse checkIfBusinessProcessStarted(CallbackParams callbackParams) {
+        CaseData caseData = callbackParams.getCaseData();
+        List<String> errors = new ArrayList<>();
+
+        if (caseData.getBusinessProcess().getStatusOrDefault() == STARTED) {
+            errors.add("Business process already started");
+        }
+
+        return AboutToStartOrSubmitCallbackResponse.builder()
+            .errors(errors)
+            .build();
     }
 
     private CallbackResponse dispatchBusinessProcess(CallbackParams callbackParams) {

--- a/src/main/java/uk/gov/hmcts/reform/unspec/handler/callback/DispatchBusinessProcessCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/handler/callback/DispatchBusinessProcessCallbackHandler.java
@@ -22,7 +22,6 @@ import static uk.gov.hmcts.reform.unspec.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.unspec.callback.CaseEvent.DISPATCH_BUSINESS_PROCESS;
 import static uk.gov.hmcts.reform.unspec.enums.BusinessProcessStatus.DISPATCHED;
 import static uk.gov.hmcts.reform.unspec.enums.BusinessProcessStatus.READY;
-import static uk.gov.hmcts.reform.unspec.enums.BusinessProcessStatus.STARTED;
 
 @Service
 @RequiredArgsConstructor
@@ -49,7 +48,7 @@ public class DispatchBusinessProcessCallbackHandler extends CallbackHandler {
         CaseData caseData = callbackParams.getCaseData();
         List<String> errors = new ArrayList<>();
 
-        if (caseData.getBusinessProcess().getStatusOrDefault() == STARTED) {
+        if (caseData.getBusinessProcess().getStatusOrDefault() != READY) {
             errors.add("Business process already started");
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/unspec/service/EventEmitterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/service/EventEmitterService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.unspec.event.DispatchBusinessProcessEvent;
 import uk.gov.hmcts.reform.unspec.model.CaseData;
 
+import static java.lang.String.format;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -16,20 +18,25 @@ public class EventEmitterService {
     private final ApplicationEventPublisher applicationEventPublisher;
     private final RuntimeService runtimeService;
 
-    public void emitBusinessProcessCamundaEvent(CaseData caseData) {
+    public void emitBusinessProcessCamundaEvent(CaseData caseData, boolean dispatchProcess) {
         var caseId = caseData.getCcdCaseReference();
         var businessProcess = caseData.getBusinessProcess();
         var camundaEvent = businessProcess.getCamundaEvent();
-        log.info(String.format("Emitting %s camunda event for case: %d", camundaEvent, caseId));
+        log.info(format("Emitting %s camunda event for case: %d", camundaEvent, caseId));
         try {
             runtimeService.createMessageCorrelation(camundaEvent)
                 .setVariable("caseId", caseId)
                 .correlateStartMessage();
-            applicationEventPublisher.publishEvent(new DispatchBusinessProcessEvent(caseId, businessProcess));
+
+            if (dispatchProcess) {
+                applicationEventPublisher.publishEvent(new DispatchBusinessProcessEvent(caseId, businessProcess));
+            }
+
             log.info("Camunda event emitted successfully");
         } catch (Exception ex) {
-            log.error(String.format("Emitting %s camunda event failed for case: %d, message: %s",
-                                    camundaEvent, caseId, ex.getMessage()));
+            log.error(format("Emitting %s camunda event failed for case: %d, message: %s",
+                             camundaEvent, caseId, ex.getMessage()
+            ));
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/unspec/service/tasks/handler/PollingEventEmitterHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/service/tasks/handler/PollingEventEmitterHandler.java
@@ -24,7 +24,6 @@ public class PollingEventEmitterHandler implements BaseExternalTaskHandler {
     private final EventEmitterService eventEmitterService;
 
     @Override
-    @EventEmitter
     public void handleTask(ExternalTask externalTask) {
         List<CaseDetails> cases = caseSearchService.getCases();
         log.info("Job '{}' found {} case(s)", externalTask.getTopicName(), cases.size());

--- a/src/main/java/uk/gov/hmcts/reform/unspec/service/tasks/handler/PollingEventEmitterHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/service/tasks/handler/PollingEventEmitterHandler.java
@@ -6,6 +6,7 @@ import org.camunda.bpm.client.task.ExternalTask;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.unspec.aspect.EventEmitter;
 import uk.gov.hmcts.reform.unspec.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.unspec.service.EventEmitterService;
 import uk.gov.hmcts.reform.unspec.service.search.CaseReadyBusinessProcessSearchService;
@@ -23,12 +24,13 @@ public class PollingEventEmitterHandler implements BaseExternalTaskHandler {
     private final EventEmitterService eventEmitterService;
 
     @Override
+    @EventEmitter
     public void handleTask(ExternalTask externalTask) {
         List<CaseDetails> cases = caseSearchService.getCases();
         log.info("Job '{}' found {} case(s)", externalTask.getTopicName(), cases.size());
         cases.stream()
             .map(caseDetailsConverter::toCaseData)
-            .forEach(eventEmitterService::emitBusinessProcessCamundaEvent);
+            .forEach(mappedCase -> eventEmitterService.emitBusinessProcessCamundaEvent(mappedCase, true));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/unspec/service/tasks/handler/PollingEventEmitterHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/service/tasks/handler/PollingEventEmitterHandler.java
@@ -6,7 +6,6 @@ import org.camunda.bpm.client.task.ExternalTask;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.unspec.aspect.EventEmitter;
 import uk.gov.hmcts.reform.unspec.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.unspec.service.EventEmitterService;
 import uk.gov.hmcts.reform.unspec.service.search.CaseReadyBusinessProcessSearchService;

--- a/src/test/java/uk/gov/hmcts/reform/unspec/aspect/EventEmitterAspectTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/aspect/EventEmitterAspectTest.java
@@ -88,7 +88,7 @@ class EventEmitterAspectTest {
 
         aspect.emitBusinessProcessEvent(proceedingJoinPoint, callbackParams);
 
-        verify(eventEmitterService).emitBusinessProcessCamundaEvent(caseData);
+        verify(eventEmitterService).emitBusinessProcessCamundaEvent(caseData, false);
         verify(proceedingJoinPoint).proceed();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/unspec/handler/callback/DispatchBusinessProcessCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/handler/callback/DispatchBusinessProcessCallbackHandlerTest.java
@@ -21,7 +21,6 @@ import static uk.gov.hmcts.reform.unspec.callback.CallbackType.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.unspec.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.unspec.enums.BusinessProcessStatus.DISPATCHED;
 import static uk.gov.hmcts.reform.unspec.enums.BusinessProcessStatus.READY;
-import static uk.gov.hmcts.reform.unspec.enums.BusinessProcessStatus.STARTED;
 
 @SpringBootTest(classes = {
     DispatchBusinessProcessCallbackHandler.class,
@@ -36,10 +35,11 @@ class DispatchBusinessProcessCallbackHandlerTest extends BaseCallbackHandlerTest
     @Nested
     class AboutToStartCallback {
 
-        @Test
-        void shouldReturnError_whenBusinessProcessIsStarted() {
+        @ParameterizedTest
+        @EnumSource(value = BusinessProcessStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"READY"})
+        void shouldReturnError_whenBusinessProcessIsStarted(BusinessProcessStatus status) {
             CaseData caseData = CaseDataBuilder.builder()
-                .businessProcess(businessProcessWithStatus(STARTED))
+                .businessProcess(businessProcessWithStatus(status))
                 .build();
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_START);
 
@@ -49,7 +49,7 @@ class DispatchBusinessProcessCallbackHandlerTest extends BaseCallbackHandlerTest
         }
 
         @Test
-        void shouldNotReturnError_whenBusinessProcessIsNotStarted() {
+        void shouldNotReturnError_whenBusinessProcessIsNotReady() {
             CaseData caseData = CaseDataBuilder.builder()
                 .businessProcess(businessProcessWithStatus(READY))
                 .build();

--- a/src/test/java/uk/gov/hmcts/reform/unspec/handler/callback/DispatchBusinessProcessCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/handler/callback/DispatchBusinessProcessCallbackHandlerTest.java
@@ -17,9 +17,11 @@ import uk.gov.hmcts.reform.unspec.sampledata.CallbackParamsBuilder;
 import uk.gov.hmcts.reform.unspec.sampledata.CaseDataBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.unspec.callback.CallbackType.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.unspec.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.unspec.enums.BusinessProcessStatus.DISPATCHED;
 import static uk.gov.hmcts.reform.unspec.enums.BusinessProcessStatus.READY;
+import static uk.gov.hmcts.reform.unspec.enums.BusinessProcessStatus.STARTED;
 
 @SpringBootTest(classes = {
     DispatchBusinessProcessCallbackHandler.class,
@@ -32,18 +34,40 @@ class DispatchBusinessProcessCallbackHandlerTest extends BaseCallbackHandlerTest
     private DispatchBusinessProcessCallbackHandler handler;
 
     @Nested
+    class AboutToStartCallback {
+
+        @Test
+        void shouldReturnError_whenBusinessProcessIsStarted() {
+            CaseData caseData = CaseDataBuilder.builder()
+                .businessProcess(businessProcessWithStatus(STARTED))
+                .build();
+            CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_START);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response.getErrors()).containsOnly("Business process already started");
+        }
+
+        @Test
+        void shouldNotReturnError_whenBusinessProcessIsNotStarted() {
+            CaseData caseData = CaseDataBuilder.builder()
+                .businessProcess(businessProcessWithStatus(READY))
+                .build();
+            CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_START);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response.getErrors()).isEmpty();
+        }
+    }
+
+    @Nested
     class AboutToSubmitCallback {
 
         @Test
         void shouldDispatchBusinessProcess_whenStatusIsReady() {
-            BusinessProcess businessProcess = BusinessProcess.builder()
-                .camundaEvent("testCamundaEvent")
-                .activityId("testActivityId")
-                .processInstanceId("testProcessInstanceId")
-                .status(READY)
-                .build();
             CaseData caseData = CaseDataBuilder.builder()
-                .businessProcess(businessProcess)
+                .businessProcess(businessProcessWithStatus(READY))
                 .build();
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
@@ -59,12 +83,7 @@ class DispatchBusinessProcessCallbackHandlerTest extends BaseCallbackHandlerTest
         @EnumSource(value = BusinessProcessStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"READY"})
         void shouldNotDispatchBusinessProcess_whenStatusIsNotReady(BusinessProcessStatus status) {
             CaseData caseData = CaseDataBuilder.builder()
-                .businessProcess(BusinessProcess.builder()
-                                     .camundaEvent("testCamundaEvent")
-                                     .activityId("testActivityId")
-                                     .processInstanceId("testProcessInstanceId")
-                                     .status(status)
-                                     .build())
+                .businessProcess(businessProcessWithStatus(status))
                 .build();
             CallbackParams params = CallbackParamsBuilder.builder().of(ABOUT_TO_SUBMIT, caseData).build();
 
@@ -78,5 +97,14 @@ class DispatchBusinessProcessCallbackHandlerTest extends BaseCallbackHandlerTest
             assertThat(response.getData()).extracting("businessProcess").extracting("processInstanceId").isEqualTo(
                 "testProcessInstanceId");
         }
+    }
+
+    private BusinessProcess businessProcessWithStatus(BusinessProcessStatus started) {
+        return BusinessProcess.builder()
+            .camundaEvent("testCamundaEvent")
+            .activityId("testActivityId")
+            .processInstanceId("testProcessInstanceId")
+            .status(started)
+            .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/unspec/handler/callback/DispatchBusinessProcessCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/handler/callback/DispatchBusinessProcessCallbackHandlerTest.java
@@ -99,12 +99,12 @@ class DispatchBusinessProcessCallbackHandlerTest extends BaseCallbackHandlerTest
         }
     }
 
-    private BusinessProcess businessProcessWithStatus(BusinessProcessStatus started) {
+    private BusinessProcess businessProcessWithStatus(BusinessProcessStatus status) {
         return BusinessProcess.builder()
             .camundaEvent("testCamundaEvent")
             .activityId("testActivityId")
             .processInstanceId("testProcessInstanceId")
-            .status(started)
+            .status(status)
             .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/unspec/service/EventEmitterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/service/EventEmitterServiceTest.java
@@ -48,12 +48,29 @@ class EventEmitterServiceTest {
             .ccdCaseReference(1L)
             .build();
 
-        eventEmitterService.emitBusinessProcessCamundaEvent(caseData);
+        eventEmitterService.emitBusinessProcessCamundaEvent(caseData, true);
 
         verify(runtimeService).createMessageCorrelation("TEST_EVENT");
         verify(messageCorrelationBuilder).setVariable("caseId", 1L);
         verify(messageCorrelationBuilder).correlateStartMessage();
         verify(applicationEventPublisher).publishEvent(new DispatchBusinessProcessEvent(1L, businessProcess));
+    }
+
+    @Test
+    void shouldSendMessageAndNotTriggerEvent_whenNotTrue() {
+        when(messageCorrelationBuilder.correlateStartMessage()).thenThrow(new RuntimeException());
+        var businessProcess = BusinessProcess.builder().camundaEvent("TEST_EVENT").build();
+        CaseData caseData = CaseData.builder()
+            .businessProcess(businessProcess)
+            .ccdCaseReference(1L)
+            .build();
+
+        eventEmitterService.emitBusinessProcessCamundaEvent(caseData, false);
+
+        verify(runtimeService).createMessageCorrelation("TEST_EVENT");
+        verify(messageCorrelationBuilder).setVariable("caseId", 1L);
+        verify(messageCorrelationBuilder).correlateStartMessage();
+        verifyNoInteractions(applicationEventPublisher);
     }
 
     @Test
@@ -65,7 +82,7 @@ class EventEmitterServiceTest {
             .ccdCaseReference(1L)
             .build();
 
-        eventEmitterService.emitBusinessProcessCamundaEvent(caseData);
+        eventEmitterService.emitBusinessProcessCamundaEvent(caseData, true);
 
         verify(runtimeService).createMessageCorrelation("TEST_EVENT");
         verify(messageCorrelationBuilder).setVariable("caseId", 1L);

--- a/src/test/java/uk/gov/hmcts/reform/unspec/service/tasks/handler/PollingEventEmitterHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/service/tasks/handler/PollingEventEmitterHandlerTest.java
@@ -79,9 +79,18 @@ class PollingEventEmitterHandlerTest {
         pollingEventEmitterHandler.execute(externalTask, externalTaskService);
 
         verify(searchService).getCases();
-        verify(eventEmitterService).emitBusinessProcessCamundaEvent(caseDetailsConverter.toCaseData(caseDetails1));
-        verify(eventEmitterService).emitBusinessProcessCamundaEvent(caseDetailsConverter.toCaseData(caseDetails2));
-        verify(eventEmitterService).emitBusinessProcessCamundaEvent(caseDetailsConverter.toCaseData(caseDetails3));
+        verify(eventEmitterService).emitBusinessProcessCamundaEvent(
+            caseDetailsConverter.toCaseData(caseDetails1),
+            true
+        );
+        verify(eventEmitterService).emitBusinessProcessCamundaEvent(
+            caseDetailsConverter.toCaseData(caseDetails2),
+            true
+        );
+        verify(eventEmitterService).emitBusinessProcessCamundaEvent(
+            caseDetailsConverter.toCaseData(caseDetails3),
+            true
+        );
         verify(externalTaskService).complete(externalTask);
 
         verifyNoMoreInteractions(eventEmitterService);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-944

### Change description ###

About to start callback on dispatch business process to not trigger if business process is started

Boolean flag on emit business process event set to true from polling event emitter, and false from submitted callbacks of events.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
