### PR TITLE
feat: additional service method options (CMC-790)

### DIFF
--- a/ccd-definition/AuthorisationCaseField/solicitor.json
+++ b/ccd-definition/AuthorisationCaseField/solicitor.json
@@ -128,6 +128,13 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "CaseFieldID": "serviceNamedPersonToRespondentSolicitor1",
+    "UserRole": "caseworker-civil-solicitor",
+    "CRUD": "CRU"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
     "CaseFieldID": "serviceLocationToRespondentSolicitor1",
     "UserRole": "caseworker-civil-solicitor",
     "CRUD": "CRU"

--- a/ccd-definition/CaseEventToFields/ConfirmService.json
+++ b/ccd-definition/CaseEventToFields/ConfirmService.json
@@ -53,6 +53,19 @@
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "UNSPECIFIED_CLAIMS",
     "CaseEventID": "CONFIRM_SERVICE",
+    "CaseFieldID": "serviceNamedPersonToRespondentSolicitor1",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "MANDATORY",
+    "PageID": "Name",
+    "PageDisplayOrder": 4,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "Y",
+    "PageShowCondition": "serviceMethodToRespondentSolicitor1.type = \"LEAVING_AT_PERMITTED_ADDRESS\" OR serviceMethodToRespondentSolicitor1.type = \"PERSONAL_SERVICE\""
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "CaseEventID": "CONFIRM_SERVICE",
     "CaseFieldID": "serviceLocationToRespondentSolicitor1",
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "MANDATORY",
@@ -87,7 +100,7 @@
     "PageDisplayOrder": 5,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
-    "FieldShowCondition": "serviceMethodToRespondentSolicitor1.type = \"FAX\" OR serviceMethodToRespondentSolicitor1.type = \"EMAIL\" OR serviceMethodToRespondentSolicitor1.type = \"OTHER\""
+    "FieldShowCondition": "serviceMethodToRespondentSolicitor1.type != \"POST\" OR serviceMethodToRespondentSolicitor1.type != \"DOCUMENT_EXCHANGE\""
   },
   {
     "LiveFrom": "01/01/2017",

--- a/ccd-definition/CaseEventToFields/ConfirmService.json
+++ b/ccd-definition/CaseEventToFields/ConfirmService.json
@@ -100,7 +100,7 @@
     "PageDisplayOrder": 5,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
-    "FieldShowCondition": "serviceMethodToRespondentSolicitor1.type != \"POST\" OR serviceMethodToRespondentSolicitor1.type != \"DOCUMENT_EXCHANGE\""
+    "FieldShowCondition": "serviceMethodToRespondentSolicitor1.type != \"POST\" AND serviceMethodToRespondentSolicitor1.type != \"DOCUMENT_EXCHANGE\""
   },
   {
     "LiveFrom": "01/01/2017",

--- a/ccd-definition/CaseField.json
+++ b/ccd-definition/CaseField.json
@@ -184,6 +184,16 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "ID": "serviceNamedPersonToRespondentSolicitor1",
+    "Label": "On whom did you serve?",
+    "FieldType": "Text",
+    "SecurityClassification": "Public",
+    "_Definition":  "The name of the person served by the applicant solicitor to the first respondent solicitor",
+    "_Category":  "CIVIL"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
     "ID": "serviceLocationToRespondentSolicitor1",
     "Label": "Where did you serve the documents?",
     "FieldType": "ServiceLocation",

--- a/ccd-definition/FixedLists/ServiceMethod.json
+++ b/ccd-definition/FixedLists/ServiceMethod.json
@@ -30,8 +30,22 @@
   {
     "LiveFrom": "01/01/2017",
     "ID": "ServiceMethod",
+    "ListElementCode": "LEAVING_AT_PERMITTED_ADDRESS",
+    "ListElement": "Leaving at permitted address",
+    "DisplayOrder": 5
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "ServiceMethod",
+    "ListElementCode": "PERSONAL_SERVICE",
+    "ListElement": "Personal service",
+    "DisplayOrder": 6
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "ID": "ServiceMethod",
     "ListElementCode": "OTHER",
     "ListElement": "Other",
-    "DisplayOrder": 5
+    "DisplayOrder": 7
   }
 ]

--- a/src/main/java/uk/gov/hmcts/reform/unspec/enums/ServiceMethodType.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/enums/ServiceMethodType.java
@@ -10,6 +10,8 @@ public enum ServiceMethodType {
     DOCUMENT_EXCHANGE(2, DateOrDateTime.DATE, "Document exchange"),
     FAX(0, DateOrDateTime.DATE_TIME, "Fax"),
     EMAIL(0, DateOrDateTime.DATE_TIME, "Email"),
+    PERSONAL_SERVICE(0, DateOrDateTime.DATE_TIME, "Personal service"),
+    LEAVING_AT_PERMITTED_ADDRESS(0, DateOrDateTime.DATE_TIME, "Leaving at permitted address"),
     OTHER(2, DateOrDateTime.DATE_TIME, "Other");
 
     private final int days;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-790

### Change description ###

New method of service options, left at permitted address and personal service
New field to get who the documents were served to

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
