### PR TITLE
fix: added retries to api tests request (CMC-NA)

### DIFF
--- a/e2e/api/request.js
+++ b/e2e/api/request.js
@@ -49,15 +49,14 @@ module.exports = {
       .then(response => response.json()).then(data => data.token);
   },
 
-  validatePage: async (eventName, pageId, caseData) => {
+  validatePage: async (eventName, pageId, caseData, expectedStatus = 200) => {
     return restHelper.request(`${getCcdDataStoreBaseUrl()}/validate?pageId=${eventName}${pageId}`, getRequestHeaders(),
       {
         data: caseData,
         event: {id: eventName},
         event_data: caseData,
         event_token: tokens.ccdEvent
-      }
-    );
+      }, 'POST', expectedStatus);
   },
 
   submitEvent: async (eventName, caseData, caseId) => {
@@ -72,6 +71,6 @@ module.exports = {
         event: {id: eventName},
         event_data: caseData,
         event_token: tokens.ccdEvent
-      });
+      }, 'POST', 201);
   }
 };

--- a/e2e/api/restHelper.js
+++ b/e2e/api/restHelper.js
@@ -4,6 +4,8 @@ const fetch = require('node-fetch');
 const HttpProxyAgent = require('http-proxy-agent');
 const HttpsProxyAgent = require('https-proxy-agent');
 
+const {retry} = require('./retryHelper');
+
 const PROXY_SERVER = `http://${config.proxyServer}`;
 const PROXY_AGENT = url => config.proxyServer
   ? url.startsWith('http:')
@@ -12,12 +14,20 @@ const PROXY_AGENT = url => config.proxyServer
   : null;
 
 module.exports = {
-  request: async (url, headers, body, method = 'POST') => {
-    return fetch(url, {
-      method: method,
-      body: body ? JSON.stringify(body) : undefined,
-      headers: headers,
-      agent: PROXY_AGENT(url)
+  request: async (url, headers, body, method = 'POST', expectedStatus = 200) => {
+    return retry(() => {
+      return fetch(url, {
+        method: method,
+        body: body ? JSON.stringify(body) : undefined,
+        headers: headers,
+        agent: PROXY_AGENT(url)
+      }).then(response => {
+        if (response.status !== expectedStatus) {
+          throw new Error(`expected status: ${expectedStatus}, actual status: ${response.status}, `
+           + `message: ${response.statusText}, url: ${response.url}`);
+        }
+        return response;
+      });
     });
   }
 };

--- a/e2e/api/retryHelper.js
+++ b/e2e/api/retryHelper.js
@@ -1,0 +1,18 @@
+const retry = (fn, remainingRetries = 3, err = null) => {
+  if (!remainingRetries) {
+    return Promise.reject(err);
+  }
+
+  return fn().catch(async err => {
+    await sleep(3000);
+    console.log('Retrying due to an error: ' + err);
+    return retry(fn, remainingRetries - 1, err);
+  });
+};
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+module.exports = {retry};
+

--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -165,7 +165,7 @@ const assertValidData = async (pageId) => {
 };
 
 const assertCallbackError = async (pageId, eventData, expectedErrorMessage) => {
-  const response = await request.validatePage(eventName, pageId, {...caseData, ...eventData});
+  const response = await request.validatePage(eventName, pageId, {...caseData, ...eventData}, 422);
   const responseBody = await response.json();
 
   assert.equal(response.status, 422);


### PR DESCRIPTION
### Change description ###

Added retries to all requests that api tests are making - sometimes an error occurs when resetting business process (race condition with camunda) or making calls to data store.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
