### PR TITLE
fix: added refreshing start event token on api tests (CMC-NA)

### DIFF
--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -174,6 +174,7 @@ const assertCallbackError = async (pageId, eventData, expectedErrorMessage) => {
 };
 
 const assertSubmittedEvent = async (expectedState, submittedCallbackResponseContains) => {
+  await request.startEvent(eventName, caseId);
   const response = await request.submitEvent(eventName, caseData, caseId);
   const responseBody = await response.json();
 


### PR DESCRIPTION
### Change description ###

409 conflict error is caused by camunda altering case data between starting and submitting event on api tests. Generating new event token just before submitting the event could resolve the issue.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
