### PR TITLE
fix: reverted confirm service camunda changes and increased number of retries for api tests (CMC-NA)

### DIFF
--- a/e2e/api/retryHelper.js
+++ b/e2e/api/retryHelper.js
@@ -1,6 +1,6 @@
 const MAX_RETRY_TIMEOUT = 30000;
 
-const retry = (fn, retryTimeout = 5000, remainingRetries = 5, err = null) => {
+const retry = (fn, retryTimeout = 5000, remainingRetries = 10, err = null) => {
   if (!remainingRetries) {
     return Promise.reject(err);
   }

--- a/src/main/resources/camunda/confirm_service.bpmn
+++ b/src/main/resources/camunda/confirm_service.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0md8je5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0md8je5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.3">
   <bpmn:process id="CONFIRM_SERVICE_PROCESS_ID" isExecutable="true">
     <bpmn:startEvent id="Event_13mnm9t" name="Start">
       <bpmn:outgoing>Flow_0kmqnoz</bpmn:outgoing>
@@ -23,16 +23,7 @@
       <bpmn:incoming>Flow_14583du</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_14583du" sourceRef="Event_1woz4jh" targetRef="Event_1rdw38r" />
-    <bpmn:serviceTask id="GenerateCertificateOfService" name="Generate Certificate of Service" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">GENERATE_CERTIFICATE_OF_SERVICE</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1t5tfh9</bpmn:incoming>
-      <bpmn:outgoing>Flow_1o7sh5h</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1t5tfh9" sourceRef="StartBusinessProcessTaskId" targetRef="GenerateCertificateOfService" />
+    <bpmn:sequenceFlow id="Flow_1t5tfh9" sourceRef="StartBusinessProcessTaskId" targetRef="Activity_1r1owoe" />
     <bpmn:callActivity id="Activity_1r1owoe" name="End Business Process" calledElement="EndBusinessProcess">
       <bpmn:extensionElements>
         <camunda:properties>
@@ -40,10 +31,9 @@
         </camunda:properties>
         <camunda:in variables="all" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1o7sh5h</bpmn:incoming>
+      <bpmn:incoming>Flow_1t5tfh9</bpmn:incoming>
       <bpmn:outgoing>Flow_1ljqldp</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:sequenceFlow id="Flow_1o7sh5h" sourceRef="GenerateCertificateOfService" targetRef="Activity_1r1owoe" />
     <bpmn:endEvent id="Event_12lb061">
       <bpmn:incoming>Flow_1ljqldp</bpmn:incoming>
     </bpmn:endEvent>
@@ -54,9 +44,13 @@
   <bpmn:error id="Error_0reyf6h" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CONFIRM_SERVICE_PROCESS_ID">
+      <bpmndi:BPMNEdge id="Flow_1ljqldp_di" bpmnElement="Flow_1ljqldp">
+        <di:waypoint x="720" y="120" />
+        <di:waypoint x="772" y="120" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1t5tfh9_di" bpmnElement="Flow_1t5tfh9">
         <di:waypoint x="360" y="120" />
-        <di:waypoint x="450" y="120" />
+        <di:waypoint x="620" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_14583du_di" bpmnElement="Flow_14583du">
         <di:waypoint x="310" y="178" />
@@ -65,14 +59,6 @@
       <bpmndi:BPMNEdge id="Flow_0kmqnoz_di" bpmnElement="Flow_0kmqnoz">
         <di:waypoint x="188" y="120" />
         <di:waypoint x="260" y="120" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1o7sh5h_di" bpmnElement="Flow_1o7sh5h">
-        <di:waypoint x="550" y="120" />
-        <di:waypoint x="620" y="120" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ljqldp_di" bpmnElement="Flow_1ljqldp">
-        <di:waypoint x="720" y="120" />
-        <di:waypoint x="772" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_13mnm9t_di" bpmnElement="Event_13mnm9t">
         <dc:Bounds x="152" y="102" width="36" height="36" />
@@ -89,14 +75,11 @@
           <dc:Bounds x="294" y="275" width="33" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0s5aldj_di" bpmnElement="GenerateCertificateOfService">
-        <dc:Bounds x="450" y="80" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_1r1owoe_di" bpmnElement="Activity_1r1owoe">
+        <dc:Bounds x="620" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_12lb061_di" bpmnElement="Event_12lb061">
         <dc:Bounds x="772" y="102" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1r1owoe_di" bpmnElement="Activity_1r1owoe">
-        <dc:Bounds x="620" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1woz4jh_di" bpmnElement="Event_1woz4jh">
         <dc:Bounds x="292" y="142" width="36" height="36" />

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/ConfirmServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/ConfirmServiceTest.java
@@ -8,9 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class ConfirmServiceTest extends BpmnBaseTest {
 
-    public static final String GENERATE_CERTIFICATE_OF_SERVICE = "GENERATE_CERTIFICATE_OF_SERVICE";
-    public static final String ACTIVITY_ID = "GenerateCertificateOfService";
-
     public ConfirmServiceTest() {
         super("confirm_service.bpmn", "CONFIRM_SERVICE_PROCESS_ID");
     }
@@ -27,10 +24,6 @@ class ConfirmServiceTest extends BpmnBaseTest {
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
         assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY);
-
-        //complete the document generation
-        ExternalTask notification = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(notification, PROCESS_CASE_EVENT, GENERATE_CERTIFICATE_OF_SERVICE, ACTIVITY_ID);
 
         //end business process
         ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);


### PR DESCRIPTION
### Change description ###

- increased number of retries for api tests
- removed confirm service camunda changes as we need code promoted first

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
