### PR TITLE
fix: add fake sendgrid key in local profile (N/A)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -149,6 +149,9 @@ docmosis:
   tornado:
     url: http://localhost:5433
 
+sendgrid:
+  api-key: fake-key
+
 testing:
   support:
     enabled: true


### PR DESCRIPTION
### Change description ###
This PR adds a fake key of sendgrid for local profile, to avoid startup failures.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
