### PR TITLE
test: added reloading case data in api tests (CMC-1013)

### DIFF
--- a/e2e/api/apiRequest.js
+++ b/e2e/api/apiRequest.js
@@ -50,7 +50,7 @@ module.exports = {
     let response = await restHelper.retriedRequest(url, getRequestHeaders(), null, 'GET')
       .then(response => response.json());
     tokens.ccdEvent = response.token;
-    return response.case_details.case_data ?? {};
+    return response.case_details.case_data || {};
   },
 
   validatePage: async (eventName, pageId, caseData, expectedStatus = 200) => {

--- a/e2e/api/apiRequest.js
+++ b/e2e/api/apiRequest.js
@@ -47,8 +47,10 @@ module.exports = {
     }
     url += `/event-triggers/${eventName}/token`;
 
-    tokens.ccdEvent = await restHelper.retriedRequest(url, getRequestHeaders(), null, 'GET')
-      .then(response => response.json()).then(data => data.token);
+    let response = await restHelper.retriedRequest(url, getRequestHeaders(), null, 'GET')
+      .then(response => response.json());
+    tokens.ccdEvent = response.token;
+    return response.case_details.case_data ?? {};
   },
 
   validatePage: async (eventName, pageId, caseData, expectedStatus = 200) => {

--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -1,7 +1,6 @@
 const assert = require('assert').strict;
 
 const apiRequest = require('./apiRequest.js');
-const {date} = require('./dataHelper');
 
 const data = {
   CREATE_CLAIM: require('../fixtures/events/createClaim.js'),

--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -31,11 +31,10 @@ module.exports = {
   },
 
   confirmService: async () => {
-    // Issue date is no longer set in create claim journey so we need to add manually.
-    caseData.claimIssuedDate = date();
-
     eventName = 'CONFIRM_SERVICE';
-    await apiRequest.startEvent(eventName, caseId);
+    let returnedCaseData = await apiRequest.startEvent(eventName, caseId);
+    assertContainsPopulatedFields(returnedCaseData);
+    caseData = returnedCaseData;
     deleteCaseFields('servedDocumentFiles');
 
     await validateEventPages();
@@ -56,7 +55,9 @@ module.exports = {
   acknowledgeService: async () => {
     eventName = 'ACKNOWLEDGE_SERVICE';
     deleteCaseFields('systemGeneratedCaseDocuments');
-    await apiRequest.startEvent(eventName, caseId);
+    let returnedCaseData = await apiRequest.startEvent(eventName, caseId);
+    assertContainsPopulatedFields(returnedCaseData);
+    caseData = returnedCaseData;
 
     await validateEventPages();
 
@@ -71,7 +72,9 @@ module.exports = {
 
   requestExtension: async () => {
     eventName = 'REQUEST_EXTENSION';
-    await apiRequest.startEvent(eventName, caseId);
+    let returnedCaseData = await apiRequest.startEvent(eventName, caseId);
+    assertContainsPopulatedFields(returnedCaseData);
+    caseData = returnedCaseData;
 
     await validateEventPages();
 
@@ -88,7 +91,9 @@ module.exports = {
 
   respondExtension: async () => {
     eventName = 'RESPOND_EXTENSION';
-    await apiRequest.startEvent(eventName, caseId);
+    let returnedCaseData = await apiRequest.startEvent(eventName, caseId);
+    assertContainsPopulatedFields(returnedCaseData);
+    caseData = returnedCaseData;
 
     await validateEventPages();
 
@@ -105,7 +110,9 @@ module.exports = {
 
   defendantResponse: async () => {
     eventName = 'DEFENDANT_RESPONSE';
-    await apiRequest.startEvent(eventName, caseId);
+    let returnedCaseData = await apiRequest.startEvent(eventName, caseId);
+    assertContainsPopulatedFields(returnedCaseData);
+    caseData = returnedCaseData;
     deleteCaseFields('respondent1', 'solicitorReferences');
 
     await validateEventPages();
@@ -125,7 +132,9 @@ module.exports = {
 
   claimantResponse: async () => {
     eventName = 'CLAIMANT_RESPONSE';
-    await apiRequest.startEvent(eventName, caseId);
+    let returnedCaseData = await apiRequest.startEvent(eventName, caseId);
+    assertContainsPopulatedFields(returnedCaseData);
+    caseData = returnedCaseData;
 
     await validateEventPages();
 
@@ -142,12 +151,13 @@ module.exports = {
 
   addDefendantLitigationFriend: async () => {
     eventName = 'ADD_DEFENDANT_LITIGATION_FRIEND';
-    await apiRequest.startEvent(eventName, caseId);
+    let returnedCaseData = await apiRequest.startEvent(eventName, caseId);
+    assertContainsPopulatedFields(returnedCaseData);
+    caseData = returnedCaseData;
 
     await validateEventPages();
   }
 };
-
 
 const validateEventPages = async () => {
   for (let pageId of Object.keys(data[eventName].valid)) {
@@ -161,10 +171,6 @@ const assertValidData = async (pageId) => {
 
   const response = await apiRequest.validatePage(eventName, pageId, caseData);
   const responseBody = await response.json();
-
-  if (response.status !== 200) {
-    console.log(responseBody);
-  }
 
   assert.equal(response.status, 200);
   assert.deepEqual(responseBody.data, caseData);
@@ -184,20 +190,22 @@ const assertSubmittedEvent = async (expectedState, submittedCallbackResponseCont
   const response = await apiRequest.submitEvent(eventName, caseData, caseId);
   const responseBody = await response.json();
 
-  if (response.status !== 201) {
-    console.log(responseBody);
-  }
-
   assert.equal(response.status, 201);
   assert.equal(responseBody.state, expectedState);
   assert.equal(responseBody.callback_response_status_code, 200);
   assert.equal(responseBody.after_submit_callback_response.confirmation_header.includes(submittedCallbackResponseContains.header), true);
   assert.equal(responseBody.after_submit_callback_response.confirmation_body.includes(submittedCallbackResponseContains.body), true);
 
-  caseData = {...caseData, ...responseBody.case_data};
   if (eventName === 'CREATE_CLAIM') {
     caseId = responseBody.id;
     console.log('Case created: ' + caseId);
+  }
+};
+
+const assertContainsPopulatedFields = returnedCaseData => {
+  for (let populatedCaseField of Object.keys(caseData)) {
+    assert.equal(populatedCaseField in returnedCaseData, true,
+      'Expected case data to contain field: ' + populatedCaseField);
   }
 };
 

--- a/src/main/java/uk/gov/hmcts/reform/unspec/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/model/CaseData.java
@@ -114,4 +114,8 @@ public class CaseData {
     }
 
     private final LitigationFriend respondent1LitigationFriend;
+
+    private final YesOrNo applicant1LitigationFriendRequired;
+
+    private final LitigationFriend applicant1LitigationFriend;
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1013

### Change description ###

- Case data is reloaded before starting each event in api tests to get fields populated by Camunda tasks
- An assertion is made to make sure that all populated fields were saved to case data - if case field is added to the definition but not to the model, it won't be saved (as `caseDetailsConverter.toMap()` output is returned in callbacks)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
