### PR TITLE
build(deps): bump jakarta.xml.bind-api from 2.3.3 to 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,7 +324,8 @@ dependencies {
   implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.11.3'
 
   // JAX-B dependencies for JDK 9+
-  implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '2.3.3'
+  implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
+  implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '3.0.0'
   implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '2.3.3'
 
   testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.6.0'


### PR DESCRIPTION
### JIRA link (if applicable) ###
[CMC-993](https://tools.hmcts.net/jira/browse/CMC-993)


### Change description ###
Bumps jakarta.xml.bind-api from 2.3.3 to 3.0.0.

Fixing the tech debt for PR:
https://github.com/hmcts/unspec-service/pull/355


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
