### PR TITLE
bug: Download sealed claim form hyperlink fix (CMC-1103)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/unspec/handler/callback/CreateClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/handler/callback/CreateClaimCallbackHandler.java
@@ -39,7 +39,7 @@ public class CreateClaimCallbackHandler extends CallbackHandler {
 
     private static final List<CaseEvent> EVENTS = Collections.singletonList(CREATE_CLAIM);
     public static final String CONFIRMATION_SUMMARY = "<br />Follow these steps to serve a claim:"
-        + "\n* <a href=\"%s\" target=\"_blank\">Download the sealed claim form</a>"
+        + "\n* [Download the sealed claim form](%s) "
         + "\n* Send the form, particulars of claim and "
         + "<a href=\"%s\" target=\"_blank\">a response pack</a> (PDF, 266 KB) to the defendant by %s"
         + "\n* Confirm service online within 21 days of sending the form, particulars and response pack, before"

--- a/src/main/java/uk/gov/hmcts/reform/unspec/handler/callback/CreateClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/handler/callback/CreateClaimCallbackHandler.java
@@ -39,7 +39,7 @@ public class CreateClaimCallbackHandler extends CallbackHandler {
 
     private static final List<CaseEvent> EVENTS = Collections.singletonList(CREATE_CLAIM);
     public static final String CONFIRMATION_SUMMARY = "<br />Follow these steps to serve a claim:"
-        + "\n* [Download the sealed claim form](%s) "
+        + "\n* [Download the sealed claim form](%s)"
         + "\n* Send the form, particulars of claim and "
         + "<a href=\"%s\" target=\"_blank\">a response pack</a> (PDF, 266 KB) to the defendant by %s"
         + "\n* Confirm service online within 21 days of sending the form, particulars and response pack, before"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1103


### Change description ###
When clicking Download sealed claim form hyperlink display the case history page in the same browser tab rather than opening a new browser tab - this will bring this hyperlink inline with the how all the other download document hyperlinks work


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
