### PR TITLE
test: incident is returned only when process instance is found

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/unspec/testingsupport/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/testingsupport/TestingSupportController.java
@@ -41,7 +41,9 @@ public class TestingSupportController {
                     .map(camundaRestEngineClient::getIncidentMessage)
                     .ifPresent(businessProcessInfo::setIncidentMessage);
             } catch (FeignException e) {
-                businessProcessInfo.setIncidentMessage(e.contentUTF8());
+                if (e.status() != 404) {
+                    businessProcessInfo.setIncidentMessage(e.contentUTF8());
+                }
             }
         }
 


### PR DESCRIPTION
### Change description ###

There's an edge case when hitting testing support endpoint in which business process can finish in short period of time between checking its status (reported as `STARTED`) and calling Camunda to get process instance details - which will return 404 if it's finished.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
