### PR TITLE
fix: suppress cve errors (N/A)

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -28,4 +28,20 @@
     <notes><![CDATA[Awaiting version bump for apache tomcat dependencies]]></notes>
     <cve>CVE-2020-13943</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[This vulnerability can only be exploited from the local network.]]></notes>
+    <gav regex="true">^org\.owasp\.encoder:encoder-jsp:.*$</gav>
+    <cve>CVE-2020-29242</cve>
+    <cve>CVE-2020-29243</cve>
+    <cve>CVE-2020-29244</cve>
+    <cve>CVE-2020-29245</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[This vulnerability can only be exploited from the local network.]]></notes>
+    <gav regex="true">^com\.nimbusds:lang-tag:.*$</gav>
+    <cve>CVE-2020-29242</cve>
+    <cve>CVE-2020-29243</cve>
+    <cve>CVE-2020-29244</cve>
+    <cve>CVE-2020-29245</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###
CVE-2020-29243
https://nvd.nist.gov/vuln/detail/CVE-2020-29243
https://vuldb.com/?id.166877
The attack needs to be initiated within the local network.
CVE-2020-29242
https://nvd.nist.gov/vuln/detail/CVE-2020-29242
https://vuldb.com/?id.166876
The attack needs to be done within the local network
CVE-2020-29245
https://nvd.nist.gov/vuln/detail/CVE-2020-29245
https://vuldb.com/?id.166879
Access to the local network is required for this attack to succeed
CVE-2020-29244
https://nvd.nist.gov/vuln/detail/CVE-2020-29244
https://vuldb.com/?id.166878
Access to the local network is required for this attack

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

