### PR TITLE
fix: retry submit click until confirmation header is visible

### DIFF
--- a/e2e/fragments/event.js
+++ b/e2e/fragments/event.js
@@ -7,8 +7,7 @@ module.exports = {
 
   async submit(buttonText, expectedMessage) {
     I.waitForText(buttonText);
-    await I.retryUntilInvisible(() => I.click(buttonText), locate('.error-summary'));
-    await I.waitForElement(CONFIRMATION_HEADER);
+    await I.retryUntilExists(() => I.click(buttonText), CONFIRMATION_HEADER);
     await within(CONFIRMATION_HEADER, () => {
       I.see(expectedMessage);
     });

--- a/e2e/steps_file.js
+++ b/e2e/steps_file.js
@@ -143,8 +143,7 @@ module.exports = function () {
       await caseViewPage.startEvent('Add litigation friend', caseId);
       await defendantLitigationFriendPage.enterLitigantFriendWithDifferentAddressToDefendant(address, TEST_FILE_PATH);
       this.waitForText('Submit');
-      this.click('Submit');
-      this.waitForElement(CASE_HEADER);
+      await this.retryUntilExists(() => this.click('Submit'), CASE_HEADER);
     },
 
     async requestExtension() {


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
