### PR TITLE
refactor: FULL_DEFENCE show hide condition in response events (CMC-1160)

### DIFF
--- a/ccd-definition/CaseEventToFields/ClaimantResponse.json
+++ b/ccd-definition/CaseEventToFields/ClaimantResponse.json
@@ -62,7 +62,7 @@
     "CaseFieldID": "applicant1DefenceResponseDocument",
     "PageDisplayOrder": 2,
     "PageFieldDisplayOrder": 1,
-    "PageShowCondition": "applicant1ProceedWithClaim = \"Yes\"",
+    "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\" AND applicant1ProceedWithClaim = \"Yes\"",
     "DisplayContext": "COMPLEX",
     "PageID": "ApplicantDefenceResponseDocument",
     "ShowSummaryChangeOption": "Y"
@@ -100,6 +100,7 @@
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "OPTIONAL",
     "PageID": "DisclosureOfNonElectronicDocuments",
+    "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\" AND applicant1ProceedWithClaim = \"Yes\"",
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/ccd-definition/CaseEventToFields/DefendantResponse.json
+++ b/ccd-definition/CaseEventToFields/DefendantResponse.json
@@ -133,6 +133,7 @@
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "OPTIONAL",
     "PageID": "DisclosureOfNonElectronicDocuments",
+    "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\"",
     "ShowSummaryChangeOption": "Y"
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1160

### Change description ###

- Added FULL_DEFENCE show hide condition to respondent1DQDisclosureOfNonElectronicDocuments page
- Added FULL_DEFENCE and applicant1ProceedWithClaim = Yes show hide conditions to applicant1DefenceResponseDocument and applicant1DQDisclosureOfNonElectronicDocuments

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
