### PR TITLE
fix: bumped dependencies for CVE-2020-29582 and added suppression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,12 @@ allprojects {
       dependencySet(group: 'com.google.guava', version: '30.1-jre') {
         entry 'guava'
       }
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-common', version: '1.4.30'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk7', version: '1.4.30'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8', version: '1.4.30'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.4.30'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: '1.4.30'
+      // CVE-2020-29582
     }
     imports {
       mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2020.0.1'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -45,10 +45,13 @@
     <cve>CVE-2020-29245</cve>
   </suppress>
   <suppress>
-    <notes><![CDATA[
-   file name: guava-28.2-jre.jar
-   ]]></notes>
+    <notes><![CDATA[file name: guava-28.2-jre.jar]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
     <cve>CVE-2020-8908</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[suppresses false positive see (https://github.com/jeremylong/DependencyCheck/issues/2785)]]></notes>
+    <cve>CVE-2020-29582</cve>
+    <cpe>cpe:/2.3:a:jetbrains:kotlin:1.4.0:milestone1:*:*:*:*:*:*</cpe>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

bumped dependencies:

-  dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-common', version: '1.4.30'
-  dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk7', version: '1.4.30'
-  dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8', version: '1.4.30'
-  dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.4.30'
-  dependency group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: '1.4.30'

Added suppression for false positive (https://github.com/jeremylong/DependencyCheck/issues/2785)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
