### PR TITLE
FIX: CMC-1306: Add payment reference enter by claimant solicitor to payload to Fee and Pay service

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/unspec/service/PaymentsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/service/PaymentsService.java
@@ -28,7 +28,7 @@ public class PaymentsService {
             .amount(claimFee.getCalculatedAmount())
             .caseReference(caseData.getLegacyCaseReference())
             .ccdCaseNumber(caseData.getCcdCaseReference().toString())
-            .customerReference("Test Customer Reference")
+            .customerReference(caseData.getPaymentReference())
             .description("Claim issue payment")
             .organisationName("Test Organisation Name")
             .service(paymentsConfiguration.getService())

--- a/src/test/java/uk/gov/hmcts/reform/unspec/service/PaymentsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/service/PaymentsServiceTest.java
@@ -73,7 +73,7 @@ class PaymentsServiceTest {
             .amount(FEE_DATA.toFeeDto().getCalculatedAmount())
             .caseReference("000LR001")
             .ccdCaseNumber("12345")
-            .customerReference("Test Customer Reference")
+            .customerReference(caseData.getPaymentReference())
             .description("Claim issue payment")
             .organisationName("Test Organisation Name")
             .service(SERVICE)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1306


### Change description ###
Add mandatory payment reference entered by claimant solicitor to the payload sent to Fee and Pay service


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
