### PR TITLE
fix: disable managementWeb in preview chart

### DIFF
--- a/charts/unspec-service/values.preview.template.yaml
+++ b/charts/unspec-service/values.preview.template.yaml
@@ -87,7 +87,7 @@ ccd:
     definitionImporter:
       enabled: false
     managementWeb:
-      enabled: true
+      enabled: false
     s2s:
       enabled: false
     postgresql:


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

 managementWeb:
      enabled: false

pods that run 

```
unspec-service-pr-584-camunda-64c84bd7c7-rq2gp                    1/1     Running            0          98s
unspec-service-pr-584-ccd-api-gw-7d46db5556-hnsm8                 1/1     Running            0          98s
unspec-service-pr-584-ccd-data-store-api-675bb586ff-gs5zn         0/1     Running            0          98s
unspec-service-pr-584-ccd-definition-store-5f88ffcd96-pbkf4       0/1     Running            0          98s
unspec-service-pr-584-ccd-user-profile-api-785967c54d-wpsst       0/1     Running            0          98s
unspec-service-pr-584-java-b4849866b-dbzbm                        1/1     Running            0          98s
unspec-service-pr-584-postgresql-0                                1/1     Running            0          98s
unspec-service-pr-584-xui-webapp-9474f9b78-p98nh                  1/1     Running            0          98s
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
