### PR TITLE
feat: map addressLine2 to dash when not available (CMC-1305)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/unspec/model/Address.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/model/Address.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import uk.gov.hmcts.reform.unspec.utils.ObjectUtils;
 
-import static java.lang.String.join;
+import static uk.gov.hmcts.reform.unspec.utils.StringUtils.joinNonNull;
 
 @Data
 @Builder
@@ -29,7 +29,7 @@ public class Address {
             addressLine2,
             addressLine3,
             postTown,
-            join(", ", county, country)
+            joinNonNull(", ", county, country)
         );
     }
 
@@ -40,7 +40,7 @@ public class Address {
             addressLine2,
             addressLine3,
             postTown,
-            join(", ", county, country)
+            joinNonNull(", ", county, country)
         );
     }
 
@@ -51,7 +51,7 @@ public class Address {
             addressLine2,
             addressLine3,
             postTown,
-            join(", ", county, country)
+            joinNonNull(", ", county, country)
         );
     }
 
@@ -62,7 +62,7 @@ public class Address {
             addressLine2,
             addressLine3,
             postTown,
-            join(", ", county, country)
+            joinNonNull(", ", county, country)
         );
     }
 
@@ -73,7 +73,7 @@ public class Address {
             addressLine2,
             addressLine3,
             postTown,
-            join(", ", county, country)
+            joinNonNull(", ", county, country)
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/unspec/service/robotics/mapper/RoboticsAddressMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/service/robotics/mapper/RoboticsAddressMapper.java
@@ -5,6 +5,8 @@ import uk.gov.hmcts.reform.unspec.model.Address;
 import uk.gov.hmcts.reform.unspec.model.robotics.RoboticsAddress;
 import uk.gov.hmcts.reform.unspec.model.robotics.RoboticsAddresses;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 @Component
@@ -14,7 +16,7 @@ public class RoboticsAddressMapper {
         requireNonNull(address);
         return RoboticsAddress.builder()
             .addressLine1(address.firstNonNull())
-            .addressLine2(address.secondNonNull())
+            .addressLine2(Optional.ofNullable(address.secondNonNull()).orElse("-"))
             .addressLine3(address.thirdNonNull())
             .addressLine4(address.fourthNonNull())
             .addressLine5(address.fifthNonNull())

--- a/src/main/java/uk/gov/hmcts/reform/unspec/utils/StringUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/unspec/utils/StringUtils.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.unspec.utils;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class StringUtils {
+
+    private StringUtils() {
+        //NO-OP
+    }
+
+    public static String joinNonNull(String delimiter, String... values) {
+        if (Arrays.stream(values).allMatch(Objects::isNull)) {
+            return null;
+        }
+        return Stream.of(values)
+            .filter(Objects::nonNull)
+            .filter(Predicate.not(String::isBlank))
+            .collect(Collectors.joining(delimiter));
+    }
+}

--- a/src/main/resources/schema/rpa-json-schema.json
+++ b/src/main/resources/schema/rpa-json-schema.json
@@ -580,7 +580,7 @@
         },
         "addressLine2": {
           "$id": "#/definitions/contactAddressType/properties/addressLine2",
-          "$ref": "#/definitions/addressLineOrNullType",
+          "$ref": "#/definitions/addressLineType",
           "description": ""
         },
         "addressLine3": {

--- a/src/test/java/uk/gov/hmcts/reform/unspec/assertion/RoboticsAddressAssert.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/assertion/RoboticsAddressAssert.java
@@ -22,7 +22,7 @@ public class RoboticsAddressAssert extends CustomAssert<RoboticsAddressAssert, R
 
         compare(
             "addressLine2",
-            expected.secondNonNull(),
+            Optional.ofNullable(expected.secondNonNull()).orElse("-"),
             Optional.ofNullable(actual.getAddressLine2())
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/unspec/service/robotics/mapper/RoboticsAddressMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/service/robotics/mapper/RoboticsAddressMapperTest.java
@@ -34,6 +34,17 @@ class RoboticsAddressMapperTest {
                          "address cannot be null"
             );
         }
+
+        @Test
+        void shouldMapToRoboticsAddressWithDefaultForAddressLine2_whenAddressLine2IsNull() {
+            Address address = Address.builder()
+                .addressLine1("address line 1")
+                .postCode("SW1 1AA").build();
+
+            RoboticsAddress roboticsAddress = mapper.toRoboticsAddress(address);
+
+            assertThat(roboticsAddress).isEqualTo(address);
+        }
     }
 
     @Nested

--- a/src/test/java/uk/gov/hmcts/reform/unspec/utils/StringUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/utils/StringUtilsTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.unspec.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static uk.gov.hmcts.reform.unspec.utils.StringUtils.joinNonNull;
+
+class StringUtilsTest {
+
+    @Test
+    void shouldReturnNull_whenAllValuesPassedAreNull() {
+        String result = joinNonNull(", ", null, null);
+        assertNull(result);
+    }
+
+    @Test
+    void shouldReturnCombined_whenValuesPassed() {
+        String result = joinNonNull(", ", "Line1", "Line2");
+        assertThat(result).isEqualTo("Line1, Line2");
+    }
+
+    @Test
+    void shouldReturnValid_whenFirstValueIsPassed() {
+        String result = joinNonNull(", ", "Line1", null);
+        assertThat(result).isEqualTo("Line1");
+    }
+
+    @Test
+    void shouldReturnValid_whenSecondValueIsPassed() {
+        String result = joinNonNull(", ", null, "Line2");
+        assertThat(result).isEqualTo("Line2");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[CMC-1305](https://tools.hmcts.net/jira/browse/CMC-1305)


### Change description ###
Map to default string "-" for RPA,  when addressLine2 is not provided.


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

