### PR TITLE
FIX: ZAP false-positive alerts

### DIFF
--- a/zap_hooks.py
+++ b/zap_hooks.py
@@ -1,4 +1,4 @@
 def zap_started(zap, target):
-  rules_to_ignore = ('90033', '10023', '10010', '10054', '100000', '100001', '10021')
+  rules_to_ignore = ('90033', '10023', '10010', '10054', '100000', '100001', '10021', '10096')
   for rule in rules_to_ignore:
     zap.pscan.set_scanner_alert_threshold(id=rule, alertthreshold='OFF')


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1347


### Change description ###
ZAP on the nightly pipeline is reporting false positives - these need to be suppressed


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
