### PR TITLE
fix: added case navigation for RPA nightly tests (CMC-1255)

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -19,6 +19,9 @@ properties([
       description: 'The URL of ccd data store'),
     string(name: 'UNSPEC_SERVICE_URL', defaultValue: 'http://unspec-service-aat.service.core-compute-aat.internal',
       description: 'The URL of unspec service'),
+    string(name: 'WAIT_FOR_TIMEOUT_MS',
+      defaultValue: '120000',
+      description: 'Functional tests waitForTimeout value'),
     string(name: 'SECURITY_RULES',
       defaultValue: 'https://raw.githubusercontent.com/hmcts/security-test-rules/master/conf/security-rules.conf',
       description: 'The security rules to use'),
@@ -57,6 +60,7 @@ withNightlyPipeline(type, product, component) {
   env.SERVICE_AUTH_PROVIDER_API_BASE_URL = params.SERVICE_AUTH_PROVIDER_API_BASE_URL
   env.CCD_DATA_STORE_URL = params.CCD_DATA_STORE_URL
   env.UNSPEC_SERVICE_URL = params.UNSPEC_SERVICE_URL
+  env.WAIT_FOR_TIMEOUT_MS = params.WAIT_FOR_TIMEOUT_MS
   env.URL_FOR_SECURITY_SCAN = params.CASE_SERVICE_URL
   loadVaultSecrets(secrets)
 

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -9,7 +9,7 @@ exports.config = {
       keepCookies: true,
       show: process.env.SHOW_BROWSER_WINDOW || false,
       windowSize: '1200x900',
-      waitForTimeout: 40000,
+      waitForTimeout: process.env.WAIT_FOR_TIMEOUT_MS || 40000,
       waitForNavigation: [ "domcontentloaded", "networkidle0" ],
       chrome: {
         ignoreHTTPSErrors: true,

--- a/e2e/steps_file.js
+++ b/e2e/steps_file.js
@@ -59,6 +59,10 @@ const welshLanguageRequirementsPage = require('./fragments/dq/language.page');
 const address = require('./fixtures/address.js');
 
 const SIGNED_IN_SELECTOR = 'exui-header';
+const JURISDICTION_LOCATOR = '#wb-jurisdiction > option';
+const TYPE_LOCATOR = '#wb-case-type > option';
+const STATE_LOCATOR = '#wb-case-state > option';
+const CASE_NUMBER_INPUT_LOCATOR = 'input[type$="number"]';
 const CASE_HEADER = 'ccd-case-header > h1';
 
 const TEST_FILE_PATH = './e2e/fixtures/examplePDF.pdf';
@@ -88,6 +92,28 @@ module.exports = function () {
       this.waitForElement(CASE_HEADER);
 
       return await this.grabTextFrom(CASE_HEADER);
+    },
+
+    async goToCase(caseId) {
+      this.click('Case list');
+
+      this.waitForElement(JURISDICTION_LOCATOR);
+      this.selectOption('jurisdiction', 'Civil');
+
+      this.waitForElement(TYPE_LOCATOR);
+      this.selectOption('case-type', 'Damages Claim');
+
+      this.waitForElement(STATE_LOCATOR);
+      this.selectOption('state', 'Any');
+
+      this.waitForElement(CASE_NUMBER_INPUT_LOCATOR);
+      this.fillField(CASE_NUMBER_INPUT_LOCATOR, caseId);
+
+      const caseLinkLocator = `a[href$="/cases/case-details/${caseId}"]`;
+      await this.retryUntilExists(() => this.click('Apply'), caseLinkLocator);
+
+      this.click(caseLinkLocator);
+      this.waitForElement(CASE_HEADER);
     },
 
     async createCase(litigantInPerson = false) {

--- a/e2e/tests/rpaHandoff_test.js
+++ b/e2e/tests/rpaHandoff_test.js
@@ -64,6 +64,7 @@ Scenario('Claimant does not respond to defence with defined timescale', async (I
   // Sleep waiting for Case strikeout scheduler
   await sleep(600);
   console.log('Waiting finished ' + dateTime());
+  await I.goToCase(caseId);
   await I.assertNoEventsAvailable();
 });
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1255

### Change description ###

- goToCase navigation for RPA nightly test - it's required for checking if no events are available once scheduler moves case offline (the page refresh doesn't work in codeceptjs, so need to navigate via UI)
- configurable waitForTimeout value - environment running nightly pipeline is slower than other pipelines - this might improve nightly build flakiness

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
