### PR TITLE
fix: added back definition for removed fields

### DIFF
--- a/ccd-definition/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/ccd-definition/AuthorisationCaseField/AuthorisationCaseField.json
@@ -1688,5 +1688,26 @@
     "CaseFieldID": "claimDismissedDate",
     "UserRoles": ["caseworker-civil-solicitor","caseworker-civil-admin"],
     "CRUD": "CRU"
+  },
+  {
+    "Comment": "Backwards compatible",
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "CaseFieldID": "defendantResponseDate",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "caseworker-civil-admin",
+          "caseworker-civil-systemupdate"
+        ],
+        "CRUD": "R"
+      }
+    ]
   }
 ]

--- a/ccd-definition/AuthorisationCaseField/systemUpdate.json
+++ b/ccd-definition/AuthorisationCaseField/systemUpdate.json
@@ -229,5 +229,33 @@
     "CaseFieldID": "detailsOfClaim",
     "UserRole": "caseworker-civil-systemupdate",
     "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "CaseFieldID": "respondentSolicitor1ResponseDeadline",
+    "UserRole": "caseworker-civil-systemupdate",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "CaseFieldID": "claimSubmittedDateTime",
+    "UserRole": "caseworker-civil-systemupdate",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "CaseFieldID": "applicantSolicitorResponseDeadlineToRespondentSolicitor1",
+    "UserRole": "caseworker-civil-systemupdate",
+    "CRUD": "R"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "CaseFieldID": "claimIssuedDate",
+    "UserRole": "caseworker-civil-systemupdate",
+    "CRUD": "CRU"
   }
 ]

--- a/ccd-definition/CaseField.json
+++ b/ccd-definition/CaseField.json
@@ -209,6 +209,15 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "ID": "claimIssuedDate",
+    "Label": "Date claim issued",
+    "FieldType": "Date",
+    "SecurityClassification": "Public",
+    "Comment": "Needs to be here temporarily for backwards compatibility"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
     "ID": "submittedDate",
     "Label": "Date claim Submitted",
     "FieldType": "DateTime",
@@ -217,10 +226,28 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "ID": "claimSubmittedDateTime",
+    "Label": "Date claim Submitted",
+    "FieldType": "DateTime",
+    "SecurityClassification": "Public",
+    "Comment": "Needs to be here temporarily for backwards compatibility"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
     "ID": "servedDocumentFiles",
     "Label": "Upload documents in the following machine readable formats",
     "FieldType": "ServedDocumentFiles",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "ID": "respondentSolicitor1ResponseDeadline",
+    "Label": "Respondent solicitor deadline",
+    "FieldType": "DateTime",
+    "SecurityClassification": "Public",
+    "Comment": "Backwards compatibility"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -301,6 +328,15 @@
     "Label": "Claimant response deadline",
     "FieldType": "DateTime",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "ID": "applicantSolicitorResponseDeadlineToRespondentSolicitor1",
+    "Label": "Claimant response deadline",
+    "FieldType": "DateTime",
+    "SecurityClassification": "Public",
+    "Comment": "Backwards compatibility"
   },
   {
     "LiveFrom": "01/01/2017",
@@ -607,6 +643,15 @@
     "Label": "Defendant response date",
     "FieldType": "DateTime",
     "SecurityClassification": "Public"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeID": "UNSPECIFIED_CLAIMS",
+    "ID": "defendantResponseDate",
+    "Label": "Defendant response date",
+    "FieldType": "Date",
+    "SecurityClassification": "Public",
+    "Comment": "Backwards compatibility"
   },
   {
     "LiveFrom": "01/01/2017",


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

Added back deleted field definition. Camunda runs on old code so sets old dates.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
